### PR TITLE
[CEN-1450] Better log on decrypt failure

### DIFF
--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterImpl.java
@@ -99,8 +99,6 @@ public class DecrypterImpl implements Decrypter {
     InputStream unencrypted = null;
     InputStream clear = null;
 
-    boolean successfulDecryption = true;
-
     try {
       JcaPGPObjectFactory pgpF = new JcaPGPObjectFactory(input);
       PGPEncryptedDataList encrypted;
@@ -159,13 +157,12 @@ public class DecrypterImpl implements Decrypter {
         throw new PGPException("Message is not a simple encrypted file - type unknown.");
       }
 
+      log.info("File Decrypted");
     } catch (PGPException e) {
       log.error("PGPException {}", e.getMessage());
-      successfulDecryption = false;
       throw e;
     } catch (IOException e) {
       log.error("IOException {}", e.getMessage());
-      successfulDecryption = false;
       throw e;
     } finally {
       keyInput.close();
@@ -176,9 +173,6 @@ public class DecrypterImpl implements Decrypter {
       if (clear != null) {
         log.info("Closing clear");
         clear.close();
-      }
-      if (successfulDecryption) {
-        log.info("File Decrypted");
       }
     }
 

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterImpl.java
@@ -82,7 +82,7 @@ public class DecrypterImpl implements Decrypter {
     } catch (Exception ex) {
       // Should throw an IOException just like decryptFile, this creates problems in the event
       // handler where the method chaining doesn't allow Exception throws
-      log.error("Cannot Decrypt. {}", ex.getMessage());
+      log.error("Cannot decrypt {}: {}", blob.getBlob(), ex.getMessage());
     }
 
     return blob;


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR improves the error log produced when the decrypt function fails by adding the information of the problematic file.
It also includes a very tiny refactoring in the DecrypterImpl class to reduce the complexity to a level acceptable by SonarCloud.

#### List of Changes

<!--- Describe your changes in detail -->
- enriched log message
- minimal refactoring (only log related, decryption logic is untouched)

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
- log messages, especially error ones, must contain all mandatory information

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Unit Test Suite
- [ ] Integration Test Suite
- [x] Api Tests
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.