### PR TITLE
[CEN-1452] Clean temporary local files

### DIFF
--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandler.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandler.java
@@ -41,6 +41,7 @@ public class EventHandler {
         .filter(b -> BlobApplicationAware.Status.DECRYPTED.equals(b.getStatus()))
         .map(blobRestConnectorImpl::put)
         .filter(b -> BlobApplicationAware.Status.UPLOADED.equals(b.getStatus()))
+        .filter(BlobApplicationAware::localCleanup)
         .collect(Collectors.toList());
   }
 

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
@@ -160,7 +160,6 @@ public class BlobApplicationAware {
    */
   public boolean localCleanup() {
     //Get the path to both encrypted and decrypted local blob files
-    //File blobEncrypted = Path.of(targetDir, blob).toFile();
     Path blobEncrypted = Path.of(targetDir, blob);
     Path blobDecrypted = Path.of(targetDir, blob + ".decrypted");
 

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
@@ -1,8 +1,8 @@
 package it.gov.pagopa.rtd.ms.rtdmsdecrypter.model;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.regex.Matcher;

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
@@ -1,7 +1,8 @@
 package it.gov.pagopa.rtd.ms.rtdmsdecrypter.model;
 
-import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Files;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.regex.Matcher;
@@ -159,8 +160,9 @@ public class BlobApplicationAware {
    */
   public boolean localCleanup() {
     //Get the path to both encrypted and decrypted local blob files
-    File blobEncrypted = Path.of(targetDir, blob).toFile();
-    File blobDecrypted = Path.of(targetDir, blob + ".decrypted").toFile();
+    //File blobEncrypted = Path.of(targetDir, blob).toFile();
+    Path blobEncrypted = Path.of(targetDir, blob);
+    Path blobDecrypted = Path.of(targetDir, blob + ".decrypted");
 
     boolean encryptedDeleted = false;
     boolean decryptedDeleted = false;
@@ -172,22 +174,26 @@ public class BlobApplicationAware {
     // Instead, warning are logged.
     //
 
-    if (blobEncrypted.exists()) {
-      encryptedDeleted = blobEncrypted.delete();
-      if (!encryptedDeleted) {
-        log.warn(FAIL_FILE_DELETE_WARNING_MSG + blobEncrypted.getPath());
+    if (Files.exists(blobEncrypted)) {
+      try {
+        Files.delete(blobEncrypted);
+        encryptedDeleted = true;
+      } catch (IOException ex) {
+        log.warn(FAIL_FILE_DELETE_WARNING_MSG + blobEncrypted + " (" + ex.getMessage() + ")");
       }
     } else {
-      log.warn(MISSING_FILE_WARNING_MSG + blobEncrypted.getPath());
+      log.warn(MISSING_FILE_WARNING_MSG + blobEncrypted);
     }
 
-    if (blobDecrypted.exists()) {
-      decryptedDeleted = blobDecrypted.delete();
-      if (!decryptedDeleted) {
-        log.warn(FAIL_FILE_DELETE_WARNING_MSG + blobDecrypted.getPath());
+    if (Files.exists(blobDecrypted)) {
+      try {
+        Files.delete(blobDecrypted);
+        decryptedDeleted = true;
+      } catch (IOException ex) {
+        log.warn(FAIL_FILE_DELETE_WARNING_MSG + blobDecrypted + " (" + ex.getMessage() + ")");
       }
     } else {
-      log.warn(MISSING_FILE_WARNING_MSG + blobDecrypted.getPath());
+      log.warn(MISSING_FILE_WARNING_MSG + blobDecrypted);
     }
 
     if (encryptedDeleted && decryptedDeleted) {

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
@@ -165,12 +165,12 @@ public class BlobApplicationAware {
     boolean encryptedDeleted = false;
     boolean decryptedDeleted = false;
 
-    /**
-     * For both files check whether they are present.
-     * If so, if their deletion has been successful.
-     * In case of failure the process isn't blocked.
-     * Instead, warning are logged.
-     */
+    //
+    // For both files check whether they are present.
+    // If so, if their deletion has been successful.
+    // In case of failure the process isn't blocked.
+    // Instead, warning are logged.
+    //
 
     if (blobEncrypted.exists()) {
       encryptedDeleted = blobEncrypted.delete();

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
@@ -1,5 +1,7 @@
 package it.gov.pagopa.rtd.ms.rtdmsdecrypter.model;
 
+import java.io.File;
+import java.nio.file.Path;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.regex.Matcher;
@@ -33,7 +35,8 @@ public class BlobApplicationAware {
     RECEIVED,
     DOWNLOADED,
     DECRYPTED,
-    UPLOADED
+    UPLOADED,
+    DELETED
   }
 
   private String blobUri;
@@ -154,8 +157,8 @@ public class BlobApplicationAware {
     File blobEncrypted = Path.of(targetDir, blob).toFile();
     File blobDecrypted = Path.of(targetDir, blob + ".decrypted").toFile();
 
-    boolean encryptedDeleted;
-    boolean decryptedDeleted;
+    boolean encryptedDeleted = false;
+    boolean decryptedDeleted = false;
 
     //For both files check whether they are present and, if so, if their deletion has been successful
     //  In case of failure the process isn't blocked
@@ -179,6 +182,9 @@ public class BlobApplicationAware {
       log.warn(MISSING_FILE_WARNING_MSG + blobDecrypted.getPath());
     }
 
+    if (encryptedDeleted && decryptedDeleted) {
+      status = Status.DELETED;
+    }
     //False is returned to filter and get rid of the event
     return false;
   }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
@@ -55,6 +55,9 @@ public class BlobApplicationAware {
   private static final String CONFLICTING_SERVICE_WARNING_MSG = "Conflicting service in URI:";
   private static final String EVENT_NOT_OF_INTEREST_WARNING_MSG = "Event not of interest:";
 
+  private static final String MISSING_FILE_WARNING_MSG = "Local blob file missing for deletion:";
+  private static final String FAIL_FILE_DELETE_WARNING_MSG = "Failed to delete local blob file:";
+
   /**
    * Constructor.
    *

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
@@ -59,7 +59,6 @@ public class BlobApplicationAware {
   private static final String CONFLICTING_SERVICE_WARNING_MSG = "Conflicting service in URI:";
   private static final String EVENT_NOT_OF_INTEREST_WARNING_MSG = "Event not of interest:";
 
-  private static final String MISSING_FILE_WARNING_MSG = "Local blob file missing for deletion:";
   private static final String FAIL_FILE_DELETE_WARNING_MSG = "Failed to delete local blob file:";
 
   /**
@@ -173,26 +172,18 @@ public class BlobApplicationAware {
     // Instead, warning are logged.
     //
 
-    if (Files.exists(blobEncrypted)) {
-      try {
-        Files.delete(blobEncrypted);
-        encryptedDeleted = true;
-      } catch (IOException ex) {
-        log.warn(FAIL_FILE_DELETE_WARNING_MSG + blobEncrypted + " (" + ex.getMessage() + ")");
-      }
-    } else {
-      log.warn(MISSING_FILE_WARNING_MSG + blobEncrypted);
+    try {
+      Files.delete(blobEncrypted);
+      encryptedDeleted = true;
+    } catch (IOException ex) {
+      log.warn(FAIL_FILE_DELETE_WARNING_MSG + blobEncrypted + " (" + ex.getMessage() + ")");
     }
 
-    if (Files.exists(blobDecrypted)) {
-      try {
-        Files.delete(blobDecrypted);
-        decryptedDeleted = true;
-      } catch (IOException ex) {
-        log.warn(FAIL_FILE_DELETE_WARNING_MSG + blobDecrypted + " (" + ex.getMessage() + ")");
-      }
-    } else {
-      log.warn(MISSING_FILE_WARNING_MSG + blobDecrypted);
+    try {
+      Files.delete(blobDecrypted);
+      decryptedDeleted = true;
+    } catch (IOException ex) {
+      log.warn(FAIL_FILE_DELETE_WARNING_MSG + blobDecrypted + " (" + ex.getMessage() + ")");
     }
 
     if (encryptedDeleted && decryptedDeleted) {

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
@@ -152,6 +152,11 @@ public class BlobApplicationAware {
     return (uriTokens[5] != null) && uriTokens[5].matches("[0-9]{3}");
   }
 
+  /**
+   * This method deletes the local files left by the blob handling (get, decrypt, put).
+   *
+   * @return false, in order to filter the event in the event handler
+   */
   public boolean localCleanup() {
     //Get the path to both encrypted and decrypted local blob files
     File blobEncrypted = Path.of(targetDir, blob).toFile();
@@ -160,9 +165,12 @@ public class BlobApplicationAware {
     boolean encryptedDeleted = false;
     boolean decryptedDeleted = false;
 
-    //For both files check whether they are present and, if so, if their deletion has been successful
-    //  In case of failure the process isn't blocked
-    //  Instead, warning are logged
+    /**
+     * For both files check whether they are present.
+     * If so, if their deletion has been successful.
+     * In case of failure the process isn't blocked.
+     * Instead, warning are logged.
+     */
 
     if (blobEncrypted.exists()) {
       encryptedDeleted = blobEncrypted.delete();

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
@@ -146,6 +146,39 @@ public class BlobApplicationAware {
     return (uriTokens[5] != null) && uriTokens[5].matches("[0-9]{3}");
   }
 
+  public boolean localCleanup() {
+    //Get the path to both encrypted and decrypted local blob files
+    File blobEncrypted = Path.of(targetDir, blob).toFile();
+    File blobDecrypted = Path.of(targetDir, blob + ".decrypted").toFile();
+
+    boolean encryptedDeleted;
+    boolean decryptedDeleted;
+
+    //For both files check whether they are present and, if so, if their deletion has been successful
+    //  In case of failure the process isn't blocked
+    //  Instead, warning are logged
+
+    if (blobEncrypted.exists()) {
+      encryptedDeleted = blobEncrypted.delete();
+      if (!encryptedDeleted) {
+        log.warn(FAIL_FILE_DELETE_WARNING_MSG + blobEncrypted.getPath());
+      }
+    } else {
+      log.warn(MISSING_FILE_WARNING_MSG + blobEncrypted.getPath());
+    }
+
+    if (blobDecrypted.exists()) {
+      decryptedDeleted = blobDecrypted.delete();
+      if (!decryptedDeleted) {
+        log.warn(FAIL_FILE_DELETE_WARNING_MSG + blobDecrypted.getPath());
+      }
+    } else {
+      log.warn(MISSING_FILE_WARNING_MSG + blobDecrypted.getPath());
+    }
+
+    //False is returned to filter and get rid of the event
+    return false;
+  }
 }
   
 

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAwareTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAwareTest.java
@@ -1,12 +1,28 @@
 package it.gov.pagopa.rtd.ms.rtdmsdecrypter.model;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 
+@SpringBootTest
+@ExtendWith(OutputCaptureExtension.class)
 class BlobApplicationAwareTest {
+
+  @Value("${decrypt.resources.base.path}")
+  String resources;
 
   @Test
   void shouldMatchRegexRTD() {
@@ -33,6 +49,59 @@ class BlobApplicationAwareTest {
   void shouldMatchNoApp(String blobUri) {
     BlobApplicationAware myBlob = new BlobApplicationAware(blobUri);
     assertSame(BlobApplicationAware.Application.NOAPP, myBlob.getApp());
+  }
+
+  @Test
+  void shouldCleanLocalFiles() throws IOException {
+    String container = "rtd-transactions-32489876908u74bh781e2db57k098c5ad00000000000";
+    String blobName = "CSTAR.99910.TRNLOG.20220316.164707.001.csv.pgp";
+
+    //Create dummy files to be deleted
+    FileOutputStream encryptedBlob = new FileOutputStream(resources + "/" + blobName);
+    FileOutputStream decryptedBlob = new FileOutputStream(
+        resources + "/" + blobName + ".decrypted");
+
+    BlobApplicationAware fakeBlob = new BlobApplicationAware(
+        "/blobServices/default/containers/" + container + "/blobs/" + blobName);
+    fakeBlob.setTargetDir(resources);
+    fakeBlob.setStatus(BlobApplicationAware.Status.DOWNLOADED);
+
+    assertFalse(fakeBlob.localCleanup());
+  }
+
+  @Test
+  void shouldFailFindingLocalEncryptedFile(CapturedOutput output) throws FileNotFoundException {
+    String container = "rtd-transactions-32489876908u74bh781e2db57k098c5ad00000000000";
+    String blobName = "CSTAR.99910.TRNLOG.20220316.164707.001.csv.pgp";
+
+    //Create dummy file to be deleted
+    FileOutputStream decryptedBlob = new FileOutputStream(
+        resources + "/" + blobName + ".decrypted");
+
+    BlobApplicationAware fakeBlob = new BlobApplicationAware(
+        "/blobServices/default/containers/" + container + "/blobs/" + blobName);
+    fakeBlob.setTargetDir(resources);
+    fakeBlob.setStatus(BlobApplicationAware.Status.DOWNLOADED);
+
+    fakeBlob.localCleanup();
+    assertThat(output.getOut(), containsString("Local blob file missing for deletion:"));
+  }
+
+  @Test
+  void shouldFailFindingLocalDecryptedFile(CapturedOutput output) throws FileNotFoundException {
+    String container = "rtd-transactions-32489876908u74bh781e2db57k098c5ad00000000000";
+    String blobName = "CSTAR.99910.TRNLOG.20220316.164707.001.csv.pgp";
+
+    //Create dummy file to be deleted
+    FileOutputStream encryptedBlob = new FileOutputStream(resources + "/" + blobName);
+
+    BlobApplicationAware fakeBlob = new BlobApplicationAware(
+        "/blobServices/default/containers/" + container + "/blobs/" + blobName);
+    fakeBlob.setTargetDir(resources);
+    fakeBlob.setStatus(BlobApplicationAware.Status.DOWNLOADED);
+
+    fakeBlob.localCleanup();
+    assertThat(output.getOut(), containsString("Local blob file missing for deletion:"));
   }
 
 }

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAwareTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAwareTest.java
@@ -84,7 +84,7 @@ class BlobApplicationAwareTest {
     fakeBlob.setStatus(BlobApplicationAware.Status.DOWNLOADED);
 
     fakeBlob.localCleanup();
-    assertThat(output.getOut(), containsString("Local blob file missing for deletion:"));
+    assertThat(output.getOut(), containsString("Failed to delete local blob file:"));
   }
 
   @Test
@@ -101,7 +101,7 @@ class BlobApplicationAwareTest {
     fakeBlob.setStatus(BlobApplicationAware.Status.DOWNLOADED);
 
     fakeBlob.localCleanup();
-    assertThat(output.getOut(), containsString("Local blob file missing for deletion:"));
+    assertThat(output.getOut(), containsString("Failed to delete local blob file:"));
   }
 
 }


### PR DESCRIPTION
#### Description
This PR fix an issue that would have led  processed files to remain stored locally.
By calling a cleanup method at the end of the event handling, the 2 files (encrypted and decrypted) are deleted.
This will grant a smoother operation, avoiding detention of useless files.

#### List of Changes

- Add temporary file cleanup logic.
- Add unit tests.

#### Motivation and Context

This change was required in order to avoid clogging the storage.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.