### PR TITLE
[CEN-1453] Modify consumer group

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,7 +29,7 @@ spring:
       bindings:
         blobStorageConsumer-in-0: # name must match [handler name]-in-0
           destination: rtd-platform-events
-          group: rtd-platform-events-consumer-group
+          group: rtd-decrypter-consumer-group
           content-type: application/json
           binder: kafka
 
@@ -51,7 +51,7 @@ spring:
       bindings:
         blobStorageConsumer-in-0: # name must match [handler name]-in-0
           destination: rtd-platform-events
-          group: rtd-platform-events-consumer-group
+          group: rtd-decrypter-consumer-group
           content-type: application/json
           binder: kafka
       kafka:


### PR DESCRIPTION
#### Description
The ingestor microservice requires a dedicated consumer group for the rtd-platform-events queue (or eventhub). To do this, it is advisable to rename the consumer groups so that they refer to the name of the microservice that uses them. Consequently it is necessary to update the kafka configuration in the decrypter microservice as well.

#### List of Changes

- Modified consumer group in application yml file

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.