### PR TITLE
[CEN-1459] improved exception log in case of failed decrypt

### DIFF
--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterImpl.java
@@ -161,11 +161,7 @@ public class DecrypterImpl implements Decrypter {
       }
 
       log.info("File Decrypted");
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-      throw e;
-    }
-      finally {
+    } finally {
       keyInput.close();
       if (unencrypted != null) {
         log.info("Closing unencrypted");

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterImpl.java
@@ -91,7 +91,8 @@ public class DecrypterImpl implements Decrypter {
   }
 
   @SneakyThrows
-  protected void decryptFile(InputStream input, OutputStream output) throws IOException, PGPException{
+  protected void decryptFile(InputStream input, OutputStream output)
+      throws IOException, PGPException {
 
     InputStream keyInput = IOUtils.toInputStream(this.privateKey, StandardCharsets.UTF_8);
     char[] passwd = this.privateKeyPassword.toCharArray();
@@ -160,7 +161,11 @@ public class DecrypterImpl implements Decrypter {
       }
 
       log.info("File Decrypted");
-    } finally {
+    } catch (IOException e) {
+      System.out.println(e.getMessage());
+      throw e;
+    }
+      finally {
       keyInput.close();
       if (unencrypted != null) {
         log.info("Closing unencrypted");

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterImpl.java
@@ -14,7 +14,6 @@ import java.util.Base64;
 import java.util.Iterator;
 import javax.annotation.PostConstruct;
 import lombok.Getter;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -79,11 +78,11 @@ public class DecrypterImpl implements Decrypter {
       blob.setStatus(BlobApplicationAware.Status.DECRYPTED);
       log.info("Blob {} decrypted.", blob.getBlob());
 
-    } catch (IOException e) {
+    } catch (IllegalArgumentException e) {
       log.warn("{}: {}", e.getMessage(), blob.getBlob());
     } catch (PGPException e) {
       log.error("Cannot decrypt {}: {}", blob.getBlob(), e.getMessage());
-    } catch (IllegalArgumentException e) {
+    } catch (IOException e) {
       log.error("Cannot decrypt {}: {}", blob.getBlob(), e.getMessage());
     }
 
@@ -126,7 +125,7 @@ public class DecrypterImpl implements Decrypter {
       }
 
       if (secretKey == null) {
-        throw new IllegalArgumentException("Secret key for message not found.");
+        throw new PGPException("Secret key for message not found.");
       }
 
       clear = pbe.getDataStream(new JcePublicKeyDataDecryptorFactoryBuilder()
@@ -150,7 +149,7 @@ public class DecrypterImpl implements Decrypter {
 
         log.info("Copying decrypted stream");
         if (StreamUtils.copy(unencrypted, output) <= 0) {
-          throw new IOException("Can't extract data from encrypted file");
+          throw new IllegalArgumentException("Can't extract data from encrypted file");
         }
 
       } else if (message instanceof PGPOnePassSignatureList) {

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterImpl.java
@@ -90,7 +90,6 @@ public class DecrypterImpl implements Decrypter {
     return blob;
   }
 
-  @SneakyThrows
   protected void decryptFile(InputStream input, OutputStream output)
       throws IOException, PGPException {
 

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterTest.java
@@ -111,10 +111,11 @@ class DecrypterTest {
       throws IOException, NoSuchProviderException, PGPException {
 
     // Try to decrypt a malformed encrypted file
+    FileInputStream myMalformedEncrypted = new FileInputStream(
+        resources + "/malformedEncrypted.pgp");
     FileOutputStream myClearText = new FileOutputStream(resources + "/file.pgp.csv.decrypted");
     assertThrows(IOException.class, () -> {
-      decrypterImpl.decryptFile(new FileInputStream(resources + "/malformedEncrypted.pgp"),
-          myClearText);
+      decrypterImpl.decryptFile(myMalformedEncrypted, myClearText);
     });
 
     myClearText.close();

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterTest.java
@@ -122,6 +122,33 @@ class DecrypterTest {
   }
 
   @Test
+  void shouldThrowIllegalArgumentExceptionFromNoData()
+      throws IOException, NoSuchProviderException, PGPException {
+
+    // Read the publicKey
+    FileInputStream publicKey = new FileInputStream(resources + "/certs/public.key");
+
+    // Encrypt an empty file
+    FileOutputStream myEmpty = new FileOutputStream(
+        resources + "/emptyFile");
+    FileOutputStream myEmptyEncrypted = new FileOutputStream(
+        resources + "/emptyEncrypted.pgp");
+    this.encryptFile(myEmptyEncrypted, resources + "/emptyFile", this.readPublicKey(publicKey),
+        true, true);
+    myEmpty.close();
+
+    FileInputStream myEncryptedEmpty = new FileInputStream(resources + "/emptyEncrypted.pgp");
+    FileOutputStream myClearText = new FileOutputStream(resources + "/file.pgp.csv.decrypted");
+
+    // Try to decrypt the empty file, resulting in an IllegalArgumentException
+    assertThrows(IllegalArgumentException.class, () -> {
+      decrypterImpl.decryptFile(myEncryptedEmpty, myClearText);
+    });
+
+    myClearText.close();
+  }
+
+  @Test
   void shouldDecrypt() throws IOException, NoSuchProviderException, PGPException {
 
     // generate file

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterTest.java
@@ -149,7 +149,7 @@ class DecrypterTest {
   }
 
   @Test
-  void shouldThrowDecryptNoData(CapturedOutput output)
+  void shouldWarnNoData(CapturedOutput output)
       throws IOException, NoSuchProviderException, PGPException {
 
     // generate file
@@ -168,7 +168,8 @@ class DecrypterTest {
     DecrypterImpl mockDecrypterImpl = mock(DecrypterImpl.class);
 
     when(mockDecrypterImpl.decrypt(any(BlobApplicationAware.class))).thenCallRealMethod();
-    doThrow(new IOException("Can't extract data from encrypted file")).when(mockDecrypterImpl)
+    doThrow(new IllegalArgumentException("Can't extract data from encrypted file")).when(
+            mockDecrypterImpl)
         .decryptFile(any(), any());
 
     fakeBlob.setTargetDir(resources);
@@ -186,7 +187,7 @@ class DecrypterTest {
     DecrypterImpl mockDecrypterImpl = mock(DecrypterImpl.class);
 
     when(mockDecrypterImpl.decrypt(any(BlobApplicationAware.class))).thenCallRealMethod();
-    doThrow(new IllegalArgumentException("Secret key for message not found.")).when(
+    doThrow(new PGPException("Secret key for message not found.")).when(
         mockDecrypterImpl).decryptFile(any(), any());
 
     fakeBlob.setTargetDir(resources);
@@ -194,36 +195,6 @@ class DecrypterTest {
     mockDecrypterImpl.decrypt(fakeBlob);
 
     assertThat(output.getOut(), containsString("Secret key for message not found."));
-  }
-
-  @Test
-  void shouldNotDecryptNoData(CapturedOutput output)
-      throws IOException, NoSuchProviderException, PGPException {
-
-    // generate file
-    String sourceFileName = "cleartext.csv";
-
-    // Read the publicKey
-    FileInputStream publicKey = new FileInputStream(
-        Path.of(resources, "/certs/public.key").toString());
-
-    // encrypt with the same routine used by batch service
-    FileOutputStream encrypted = new FileOutputStream(Path.of(resources, blobName).toString());
-    this.encryptFile(encrypted, Path.of(resources, sourceFileName).toString(),
-        this.readPublicKey(publicKey), false, true);
-
-    //Partially mocked decrypter
-    DecrypterImpl mockDecrypterImpl = mock(DecrypterImpl.class);
-
-    when(mockDecrypterImpl.decrypt(any(BlobApplicationAware.class))).thenCallRealMethod();
-    doThrow(new IOException("Can't extract data from encrypted file")).when(mockDecrypterImpl)
-        .decryptFile(any(), any());
-
-    fakeBlob.setTargetDir(resources);
-    fakeBlob.setStatus(BlobApplicationAware.Status.DOWNLOADED);
-    mockDecrypterImpl.decrypt(fakeBlob);
-
-    assertThat(output.getOut(), containsString("Can't extract data from encrypted file"));
   }
 
   @Test


### PR DESCRIPTION
#### Description
The decryptFile method can throw exceptions which are caught in the decrypt method.
In edge cases (such as decrypting an empty file) “Cannot decrypt” is generically reported, even if in fact the file has been decrypted.
We therefore want to make the handling of exceptions more granular in this phase in order to make troubleshooting easier.

#### List of Changes

- Changed the location of catch clause from method decryptFile to decrypt.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.