### PR TITLE
[CEN-1486] Delete local files on failed decrypt

### DIFF
--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterTest.java
@@ -387,4 +387,19 @@ class DecrypterTest {
     throw new IllegalArgumentException("Can't find encryption key in key ring.");
   }
 
+  /**
+   * Some tests create local files. This method is called at the end of them to clean up those
+   * temporary files, avoiding clogging the resource directory during testing.
+   *
+   * @param filenames varargs of local file names to be deleted.
+   */
+  void cleanLocalTestFiles(String... filenames) {
+    try {
+      for (String f : filenames) {
+        Files.delete(Path.of(resources, f));
+      }
+    } catch (Exception e) {
+      System.err.println(e.getMessage());
+    }
+  }
 }


### PR DESCRIPTION
#### Description
The locally downloaded blob, in case of failed decrypt, will not continue its way in the event handler.
This implies to not clean the temporary local files, with a consequent increase in the size of the instance.
The local files cleaning method must be called after the failure, to avoid the accumulation of useless files.

#### List of Changes

- Call of localCleanup after a decrypt failure.
- Added a cleanup method for test files, in order to avoid bloating resource folder during tests.

#### Motivation and Context

This change is mandatory to avoid bloating the storage with failing blolbs.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.