### PR TITLE
[CEN-1483] Better log in case of successful decrypt

### DIFF
--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterImpl.java
@@ -170,7 +170,6 @@ public class DecrypterImpl implements Decrypter {
         throw new PGPException("Message is not a simple encrypted file - type unknown.");
       }
 
-      log.info("File {} decrypted", blobName);
     } finally {
       keyInput.close();
       if (unencrypted != null) {

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterImpl.java
@@ -78,7 +78,7 @@ public class DecrypterImpl implements Decrypter {
 
       this.decryptFile(encrypted, decrypted, blob.getBlob());
       blob.setStatus(BlobApplicationAware.Status.DECRYPTED);
-      log.info("Blob {} decrypted.", blob.getBlob());
+      log.info("Blob decrypted: {}", blob.getBlob());
 
     } catch (IllegalArgumentException e) {
       log.warn("{}: {}", e.getMessage(), blob.getBlob());
@@ -158,7 +158,7 @@ public class DecrypterImpl implements Decrypter {
 
         unencrypted = ld.getInputStream();
 
-        log.info("Copying decrypted stream from {}", blobName);
+        log.info("Copying decrypted stream: {}", blobName);
         if (StreamUtils.copy(unencrypted, output) <= 0) {
           throw new IllegalArgumentException("Can't extract data from encrypted file");
         }
@@ -172,11 +172,11 @@ public class DecrypterImpl implements Decrypter {
     } finally {
       keyInput.close();
       if (unencrypted != null) {
-        log.info("Closing unencrypted {}", blobName+".decrypted");
+        log.info("Closing: {}", blobName + ".decrypted");
         unencrypted.close();
       }
       if (clear != null) {
-        log.info("Closing clear stream taken from {}'s decryption", blobName);
+        log.info("Closing clear stream: {}", blobName);
         clear.close();
       }
     }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterImpl.java
@@ -92,7 +92,7 @@ public class DecrypterImpl implements Decrypter {
     }
 
     // If the decrypt failed this call to localCleanup ensures that no local files are left
-    // On a non-failing scenario the event reaches the end of the handler and the cleanup method is called
+    // On a non-failing scenario the files are cleaned at the end of the handler
     if (decryptFailed) {
       blob.localCleanup();
     }

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterTest.java
@@ -81,7 +81,8 @@ class DecrypterTest {
   }
 
   @Test
-  void shouldDecryptFile() throws IOException, NoSuchProviderException, PGPException {
+  void shouldDecryptFile(CapturedOutput output)
+      throws IOException, NoSuchProviderException, PGPException {
 
     // generate file
     String sourceFileName = "cleartext.csv";
@@ -106,6 +107,11 @@ class DecrypterTest {
         new BufferedReader(
             new FileReader(Path.of(resources, "/file.pgp.csv.decrypted").toFile()))));
 
+    //Ensures, through log info, that all file decrypting steps are done
+    assertThat(output.getOut(), containsString("Copying decrypted stream:"));
+    assertThat(output.getOut(), containsString("Closing:"));
+    assertThat(output.getOut(), containsString("Closing clear stream:"));
+
     cleanLocalTestFiles("encrypted.pgp", "file.pgp.csv.decrypted");
   }
 
@@ -127,7 +133,7 @@ class DecrypterTest {
   }
 
   @Test
-  void shouldThrowIllegalArgumentExceptionFromDecryptingEncryptedNoData()
+  void shouldThrowIllegalArgumentExceptionFromDecryptingEncryptedNoData(CapturedOutput output)
       throws IOException, NoSuchProviderException, PGPException {
 
     // Read the publicKey
@@ -154,11 +160,17 @@ class DecrypterTest {
     myEmptyEncryptedInput.close();
     myClearText.close();
 
+    //Ensures, through log info, that the correct decrypting steps are done
+    assertThat(output.getOut(), containsString("Copying decrypted stream:"));
+    assertThat(output.getOut(), containsString("Closing:"));
+    assertThat(output.getOut(), containsString("Closing clear stream:"));
+
     cleanLocalTestFiles("emptyFile", "emptyFile.pgp", "emptyFile.decrypted");
   }
 
   @Test
-  void shouldDecrypt() throws IOException, NoSuchProviderException, PGPException {
+  void shouldDecrypt(CapturedOutput output)
+      throws IOException, NoSuchProviderException, PGPException {
 
     // generate file
     String sourceFileName = "cleartext.csv";
@@ -186,6 +198,12 @@ class DecrypterTest {
     //Check if the local blob and the decrypted one aren't cleaned up
     assertTrue(Files.exists(Path.of(resources, blobName)) && Files.exists(
         Path.of(resources, blobName + ".decrypted")));
+
+    //Ensures, through log info, that all decrypting steps are done
+    assertThat(output.getOut(), containsString("Copying decrypted stream:"));
+    assertThat(output.getOut(), containsString("Closing:"));
+    assertThat(output.getOut(), containsString("Closing clear stream:"));
+    assertThat(output.getOut(), containsString("Blob decrypted:"));
 
     cleanLocalTestFiles(blobName, blobName + ".decrypted");
   }

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterTest.java
@@ -82,7 +82,7 @@ class DecrypterTest {
     FileInputStream myEncrypted = new FileInputStream(resources + "/encrypted.pgp");
     FileOutputStream myClearText = new FileOutputStream(resources + "/file.pgp.csv.decrypted");
 
-    decrypterImpl.decryptFile(myEncrypted, myClearText);
+    decrypterImpl.decryptFile(myEncrypted, myClearText, "encrypted.pgp");
     myClearText.close();
 
     assertTrue(IOUtils.contentEquals(
@@ -99,7 +99,7 @@ class DecrypterTest {
     FileOutputStream myClearText = new FileOutputStream(resources + "/file.pgp.csv.decrypted");
     assertThrows(IOException.class, () -> {
       decrypterImpl.decryptFile(new FileInputStream(resources + "/malformedEncrypted.pgp"),
-          myClearText);
+          myClearText, "malformedEncrypted.pgp");
     });
 
     myClearText.close();

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterTest.java
@@ -98,7 +98,7 @@ class DecrypterTest {
     FileInputStream myEncrypted = new FileInputStream(resources + "/encrypted.pgp");
     FileOutputStream myClearText = new FileOutputStream(resources + "/file.pgp.csv.decrypted");
 
-    decrypterImpl.decryptFile(myEncrypted, myClearText);
+    decrypterImpl.decryptFile(myEncrypted, myClearText, "encrypted.pgp");
     myClearText.close();
 
     assertTrue(IOUtils.contentEquals(
@@ -118,7 +118,7 @@ class DecrypterTest {
         resources + "/malformedEncrypted.pgp");
     FileOutputStream myClearText = new FileOutputStream(resources + "/malformedFile.decrypted");
     assertThrows(IOException.class, () -> {
-      decrypterImpl.decryptFile(myMalformedEncrypted, myClearText);
+      decrypterImpl.decryptFile(myMalformedEncrypted, myClearText, "malformedEncrypted.pgp");
     });
 
     myClearText.close();
@@ -149,7 +149,7 @@ class DecrypterTest {
 
     // Try to decrypt the empty file, resulting in an IllegalArgumentException
     assertThrows(IllegalArgumentException.class, () -> {
-      decrypterImpl.decryptFile(myEmptyEncryptedInput, myClearText);
+      decrypterImpl.decryptFile(myEmptyEncryptedInput, myClearText, blobName);
     });
     myEmptyEncryptedInput.close();
     myClearText.close();
@@ -212,7 +212,7 @@ class DecrypterTest {
     when(mockDecrypterImpl.decrypt(any(BlobApplicationAware.class))).thenCallRealMethod();
     doThrow(new IllegalArgumentException("Can't extract data from encrypted file")).when(
             mockDecrypterImpl)
-        .decryptFile(any(), any());
+        .decryptFile(any(), any(), any());
 
     BlobApplicationAware fakeBlob = new BlobApplicationAware(
         "/blobServices/default/containers/" + container + "/blobs/" + blobName);
@@ -235,7 +235,7 @@ class DecrypterTest {
 
     when(mockDecrypterImpl.decrypt(any(BlobApplicationAware.class))).thenCallRealMethod();
     doThrow(new PGPException("Secret key for message not found.")).when(
-        mockDecrypterImpl).decryptFile(any(), any());
+        mockDecrypterImpl).decryptFile(any(), any(), any());
 
     String blobName = "CSTAR.99910.TRNLOG.20220228.103107.001.csv.pgp.nosecretkey";
     FileOutputStream encrypted = new FileOutputStream(Path.of(resources, blobName).toString());
@@ -274,7 +274,7 @@ class DecrypterTest {
     when(mockDecrypterImpl.decrypt(any(BlobApplicationAware.class))).thenCallRealMethod();
     doThrow(
         new IOException("invalid armor")).when(
-        mockDecrypterImpl).decryptFile(any(), any());
+        mockDecrypterImpl).decryptFile(any(), any(), any());
 
     fakeBlob.setTargetDir(resources);
     fakeBlob.setStatus(BlobApplicationAware.Status.DOWNLOADED);
@@ -308,7 +308,7 @@ class DecrypterTest {
     when(mockDecrypterImpl.decrypt(any(BlobApplicationAware.class))).thenCallRealMethod();
     doThrow(
         new PGPException("Encrypted message contains a signed message - not literal data.")).when(
-        mockDecrypterImpl).decryptFile(any(), any());
+        mockDecrypterImpl).decryptFile(any(), any(), any());
 
     fakeBlob.setTargetDir(resources);
     fakeBlob.setStatus(BlobApplicationAware.Status.DOWNLOADED);
@@ -342,7 +342,7 @@ class DecrypterTest {
 
     when(mockDecrypterImpl.decrypt(any(BlobApplicationAware.class))).thenCallRealMethod();
     doThrow(new PGPException("Message is not a simple encrypted file - type unknown.")).when(
-        mockDecrypterImpl).decryptFile(any(), any());
+        mockDecrypterImpl).decryptFile(any(), any(), any());
 
     fakeBlob.setTargetDir(resources);
     fakeBlob.setStatus(BlobApplicationAware.Status.DOWNLOADED);

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterTest.java
@@ -1,8 +1,14 @@
 package it.gov.pagopa.rtd.ms.rtdmsdecrypter.service;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import it.gov.pagopa.rtd.ms.rtdmsdecrypter.model.BlobApplicationAware;
 import java.io.BufferedReader;
@@ -36,15 +42,19 @@ import org.bouncycastle.openpgp.operator.jcajce.JcaKeyFingerprintCalculator;
 import org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder;
 import org.bouncycastle.openpgp.operator.jcajce.JcePublicKeyKeyEncryptionMethodGenerator;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
 @ContextConfiguration(classes = {DecrypterImpl.class})
 @TestPropertySource(value = {"classpath:application-nokafka.yml"}, inheritProperties = false)
+@ExtendWith(OutputCaptureExtension.class)
 class DecrypterTest {
 
   @Autowired
@@ -55,6 +65,11 @@ class DecrypterTest {
 
   @Value("${decrypt.private.key.password}")
   String privateKeyPassword;
+
+  String container = "rtd-transactions-32489876908u74bh781e2db57k098c5ad00000000000";
+  String blobName = "CSTAR.99910.TRNLOG.20220228.103107.001.csv.pgp";
+  BlobApplicationAware fakeBlob = new BlobApplicationAware(
+      "/blobServices/default/containers/" + container + "/blobs/" + blobName);
 
   @Test
   void shouldDecodeBase64File() throws IOException {
@@ -82,7 +97,7 @@ class DecrypterTest {
     FileInputStream myEncrypted = new FileInputStream(resources + "/encrypted.pgp");
     FileOutputStream myClearText = new FileOutputStream(resources + "/file.pgp.csv.decrypted");
 
-    decrypterImpl.decryptFile(myEncrypted, myClearText, "encrypted.pgp");
+    decrypterImpl.decryptFile(myEncrypted, myClearText);
     myClearText.close();
 
     assertTrue(IOUtils.contentEquals(
@@ -96,10 +111,38 @@ class DecrypterTest {
       throws IOException, NoSuchProviderException, PGPException {
 
     // Try to decrypt a malformed encrypted file
+    FileInputStream myMalformedEncrypted = new FileInputStream(
+        resources + "/malformedEncrypted.pgp");
     FileOutputStream myClearText = new FileOutputStream(resources + "/file.pgp.csv.decrypted");
     assertThrows(IOException.class, () -> {
-      decrypterImpl.decryptFile(new FileInputStream(resources + "/malformedEncrypted.pgp"),
-          myClearText, "malformedEncrypted.pgp");
+      decrypterImpl.decryptFile(myMalformedEncrypted, myClearText);
+    });
+
+    myClearText.close();
+  }
+
+  @Test
+  void shouldThrowIllegalArgumentExceptionFromNoData()
+      throws IOException, NoSuchProviderException, PGPException {
+
+    // Read the publicKey
+    FileInputStream publicKey = new FileInputStream(resources + "/certs/public.key");
+
+    // Encrypt an empty file
+    FileOutputStream myEmpty = new FileOutputStream(
+        resources + "/emptyFile");
+    FileOutputStream myEmptyEncrypted = new FileOutputStream(
+        resources + "/emptyEncrypted.pgp");
+    this.encryptFile(myEmptyEncrypted, resources + "/emptyFile", this.readPublicKey(publicKey),
+        true, true);
+    myEmpty.close();
+
+    FileInputStream myEncryptedEmpty = new FileInputStream(resources + "/emptyEncrypted.pgp");
+    FileOutputStream myClearText = new FileOutputStream(resources + "/file.pgp.csv.decrypted");
+
+    // Try to decrypt the empty file, resulting in an IllegalArgumentException
+    assertThrows(IllegalArgumentException.class, () -> {
+      decrypterImpl.decryptFile(myEncryptedEmpty, myClearText);
     });
 
     myClearText.close();
@@ -107,9 +150,6 @@ class DecrypterTest {
 
   @Test
   void shouldDecrypt() throws IOException, NoSuchProviderException, PGPException {
-
-    String container = "rtd-transactions-32489876908u74bh781e2db57k098c5ad00000000000";
-    String blobName = "CSTAR.99910.TRNLOG.20220228.103107.001.csv.pgp";
 
     // generate file
     String sourceFileName = "cleartext.csv";
@@ -123,9 +163,6 @@ class DecrypterTest {
     this.encryptFile(encrypted, Path.of(resources, sourceFileName).toString(),
         this.readPublicKey(publicKey), false, true);
 
-    BlobApplicationAware fakeBlob = new BlobApplicationAware(
-        "/blobServices/default/containers/" + container + "/blobs/" + blobName);
-
     // decrypt and compare
     fakeBlob.setTargetDir(resources);
     fakeBlob.setStatus(BlobApplicationAware.Status.DOWNLOADED);
@@ -136,6 +173,148 @@ class DecrypterTest {
         new BufferedReader(
             new FileReader(Path.of(resources, fakeBlob.getBlob() + ".decrypted").toFile()))
     ));
+  }
+
+  @Test
+  void shouldWarnNoData(CapturedOutput output)
+      throws IOException, NoSuchProviderException, PGPException {
+
+    // generate file
+    String sourceFileName = "cleartext.csv";
+
+    // Read the publicKey
+    FileInputStream publicKey = new FileInputStream(
+        Path.of(resources, "/certs/public.key").toString());
+
+    // encrypt with the same routine used by batch service
+    FileOutputStream encrypted = new FileOutputStream(Path.of(resources, blobName).toString());
+    this.encryptFile(encrypted, Path.of(resources, sourceFileName).toString(),
+        this.readPublicKey(publicKey), false, true);
+
+    //Partially mocked decrypter
+    DecrypterImpl mockDecrypterImpl = mock(DecrypterImpl.class);
+
+    when(mockDecrypterImpl.decrypt(any(BlobApplicationAware.class))).thenCallRealMethod();
+    doThrow(new IllegalArgumentException("Can't extract data from encrypted file")).when(
+            mockDecrypterImpl)
+        .decryptFile(any(), any());
+
+    fakeBlob.setTargetDir(resources);
+    fakeBlob.setStatus(BlobApplicationAware.Status.DOWNLOADED);
+    mockDecrypterImpl.decrypt(fakeBlob);
+
+    assertThat(output.getOut(), containsString("Can't extract data from encrypted file"));
+  }
+
+  @Test
+  void shouldFailDecryptNoSecretKey(CapturedOutput output)
+      throws IOException, NoSuchProviderException, PGPException {
+
+    //Partially mocked decrypter
+    DecrypterImpl mockDecrypterImpl = mock(DecrypterImpl.class);
+
+    when(mockDecrypterImpl.decrypt(any(BlobApplicationAware.class))).thenCallRealMethod();
+    doThrow(new PGPException("Secret key for message not found.")).when(
+        mockDecrypterImpl).decryptFile(any(), any());
+
+    fakeBlob.setTargetDir(resources);
+    fakeBlob.setStatus(BlobApplicationAware.Status.DOWNLOADED);
+    mockDecrypterImpl.decrypt(fakeBlob);
+
+    assertThat(output.getOut(), containsString("Secret key for message not found."));
+  }
+
+  @Test
+  void shouldNotDecryptIOException(CapturedOutput output)
+      throws IOException, NoSuchProviderException, PGPException {
+
+    String sourceFileName = "cleartext.csv";
+
+    // Read the publicKey
+    FileInputStream publicKey = new FileInputStream(
+        Path.of(resources, "/certs/public.key").toString());
+
+    // encrypt with the same routine used by batch service
+    FileOutputStream encrypted = new FileOutputStream(Path.of(resources, blobName).toString());
+    this.encryptFile(encrypted, Path.of(resources, sourceFileName).toString(),
+        this.readPublicKey(publicKey), false, true);
+
+    //Partially mocked decrypter
+    DecrypterImpl mockDecrypterImpl = mock(DecrypterImpl.class);
+
+    when(mockDecrypterImpl.decrypt(any(BlobApplicationAware.class))).thenCallRealMethod();
+    doThrow(
+        new IOException("invalid armor")).when(
+        mockDecrypterImpl).decryptFile(any(), any());
+
+    fakeBlob.setTargetDir(resources);
+    fakeBlob.setStatus(BlobApplicationAware.Status.DOWNLOADED);
+    mockDecrypterImpl.decrypt(fakeBlob);
+
+    assertThat(output.getOut(),
+        containsString("invalid armor"));
+  }
+
+  @Test
+  void shouldNotDecryptNoLiteralData(CapturedOutput output)
+      throws IOException, NoSuchProviderException, PGPException {
+
+    String sourceFileName = "cleartext.csv";
+
+    // Read the publicKey
+    FileInputStream publicKey = new FileInputStream(
+        Path.of(resources, "/certs/public.key").toString());
+
+    // encrypt with the same routine used by batch service
+    FileOutputStream encrypted = new FileOutputStream(Path.of(resources, blobName).toString());
+    this.encryptFile(encrypted, Path.of(resources, sourceFileName).toString(),
+        this.readPublicKey(publicKey), false, true);
+
+    //Partially mocked decrypter
+    DecrypterImpl mockDecrypterImpl = mock(DecrypterImpl.class);
+
+    when(mockDecrypterImpl.decrypt(any(BlobApplicationAware.class))).thenCallRealMethod();
+    doThrow(
+        new PGPException("Encrypted message contains a signed message - not literal data.")).when(
+        mockDecrypterImpl).decryptFile(any(), any());
+
+    fakeBlob.setTargetDir(resources);
+    fakeBlob.setStatus(BlobApplicationAware.Status.DOWNLOADED);
+    mockDecrypterImpl.decrypt(fakeBlob);
+
+    assertThat(output.getOut(),
+        containsString("Encrypted message contains a signed message - not literal data."));
+  }
+
+  @Test
+  void shouldNotDecryptTypeUnknown(CapturedOutput output)
+      throws IOException, NoSuchProviderException, PGPException {
+
+    // generate file
+    String sourceFileName = "cleartext.csv";
+
+    // Read the publicKey
+    FileInputStream publicKey = new FileInputStream(
+        Path.of(resources, "/certs/public.key").toString());
+
+    // encrypt with the same routine used by batch service
+    FileOutputStream encrypted = new FileOutputStream(Path.of(resources, blobName).toString());
+    this.encryptFile(encrypted, Path.of(resources, sourceFileName).toString(),
+        this.readPublicKey(publicKey), false, true);
+
+    //Partially mocked decrypter
+    DecrypterImpl mockDecrypterImpl = mock(DecrypterImpl.class);
+
+    when(mockDecrypterImpl.decrypt(any(BlobApplicationAware.class))).thenCallRealMethod();
+    doThrow(new PGPException("Message is not a simple encrypted file - type unknown.")).when(
+        mockDecrypterImpl).decryptFile(any(), any());
+
+    fakeBlob.setTargetDir(resources);
+    fakeBlob.setStatus(BlobApplicationAware.Status.DOWNLOADED);
+    mockDecrypterImpl.decrypt(fakeBlob);
+
+    assertThat(output.getOut(),
+        containsString("Message is not a simple encrypted file - type unknown."));
   }
 
   // This routine should be factored out in a common module


### PR DESCRIPTION
#### Description
In case of successful decrypt, the log messages are insufficient if you want to understand which blob storage they refer to.
Adding a reference to the blob to each log message also eliminates the assumption that they are shown in succession (in the case of concurrent program executions).

#### List of Changes

- Changed the signature of the decryptFile method to accept also the name of the blob.
- Adapted the test accordingly.
- Enforced test with assertions on successful decrypt logs.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Considering troubleshooting done with log, precise information are required even in case of successful decrypt.
The old version just logged a message of success without giving hints on the target blob.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.