### PR TITLE
[CEN-1505] Parametric line threshold

### DIFF
--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobSplitterImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobSplitterImpl.java
@@ -1,7 +1,6 @@
 package it.gov.pagopa.rtd.ms.rtdmsdecrypter.service;
 
 import it.gov.pagopa.rtd.ms.rtdmsdecrypter.model.BlobApplicationAware;
-import it.gov.pagopa.rtd.ms.rtdmsdecrypter.model.BlobApplicationAware.Status;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.Writer;
@@ -10,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.stream.Stream;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.LineIterator;
@@ -20,11 +20,12 @@ import org.springframework.stereotype.Service;
  * Concrete implementation of a BlobSplitter interface.
  */
 @Service
+@Setter
 @Slf4j
 public class BlobSplitterImpl implements BlobSplitter {
 
   //Max number of lines allowed in one blob chunk.
-  @Value("${splitter.threshold}")
+  @Value("${decrypt.splitter.threshold}")
   private int lineThreshold;
 
   /**
@@ -34,7 +35,6 @@ public class BlobSplitterImpl implements BlobSplitter {
    * @return a list of blobs that represent the split blob.
    */
   public Stream<BlobApplicationAware> split(BlobApplicationAware blob) {
-    int n = 1;
     String blobPath = Path.of(blob.getTargetDir(), blob.getBlob() + ".decrypted").toString();
 
     ArrayList<BlobApplicationAware> blobSplit = new ArrayList<>();

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobSplitterImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobSplitterImpl.java
@@ -54,7 +54,7 @@ public class BlobSplitterImpl implements BlobSplitter {
                 true).getChannel(),
             StandardCharsets.UTF_8)) {
           i = 0;
-          while (i < n) {
+          while (i < lineThreshold) {
             if (it.hasNext()) {
               String line = it.nextLine();
               writer.append(line).append("\n");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ decrypt:
     base:
       path: src/test/resources
   private:
-    key: 
+    key:
       path: ${CSV_TRANSACTION_PRIVATE_KEY_PATH:${decrypt.resources.base.path}/certs/private_base64.key} # just for tests
       password: ${CSV_TRANSACTION_PRIVATE_KEY_PASS:privatekeypass}
   api:
@@ -18,9 +18,8 @@ decrypt:
     targetContainer:
       rtd: rtd-transactions-decrypted
       ade: ade-transactions-decrypted
-
-splitter:
-  threshold: 100000
+  splitter:
+    threshold: 10000
 ---
 spring:
   config:
@@ -39,12 +38,12 @@ spring:
         binder:
           auto-create-topics: false
           consumerProperties:
-            key: 
+            key:
               deserializer: org.apache.kafka.common.serialization.StringDeserializer
             value:
               deserializer: org.apache.kafka.common.serialization.StringDeserializer
 ---
-spring: 
+spring:
   config:
     activate:
       on-profile: default
@@ -58,8 +57,8 @@ spring:
           binder: kafka
       kafka:
         binder:
-          auto-create-topics: false 
-          brokers: ${KAFKA_BROKER}          
+          auto-create-topics: false
+          brokers: ${KAFKA_BROKER}
           configuration:
             sasl:
               jaas:
@@ -68,7 +67,7 @@ spring:
             security:
               protocol: SASL_SSL
           consumerProperties:
-            key: 
+            key:
               deserializer: org.apache.kafka.common.serialization.StringDeserializer
             value:
               deserializer: org.apache.kafka.common.serialization.StringDeserializer

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobSplitterTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobSplitterTest.java
@@ -53,6 +53,7 @@ class BlobSplitterTest {
 
     fakeBlob.setTargetDir(resources);
     fakeBlob.setStatus(BlobApplicationAware.Status.DOWNLOADED);
+    blobSplitterImpl.setLineThreshold(1);
 
     assertEquals(3, blobSplitterImpl.split(fakeBlob).count());
 
@@ -69,6 +70,7 @@ class BlobSplitterTest {
 
     fakeBlob.setTargetDir(resources);
     fakeBlob.setStatus(BlobApplicationAware.Status.DOWNLOADED);
+    blobSplitterImpl.setLineThreshold(1);
 
     blobSplitterImpl.split(fakeBlob);
     assertThat(output.getOut(), containsString("Missing blob file:"));

--- a/src/test/resources/application-nokafka.yml
+++ b/src/test/resources/application-nokafka.yml
@@ -3,9 +3,8 @@ decrypt:
     base:
       path: src/test/resources
   private:
-    key: 
+    key:
       path: ${CSV_TRANSACTION_PRIVATE_KEY_PATH:${decrypt.resources.base.path}/certs/private_base64.key} # just for tests
       password: ${CSV_TRANSACTION_PRIVATE_KEY_PASS:privatekeypass}
-
-splitter:
-  threshold: 100000
+  splitter:
+    threshold: 10000


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
The blob is split into a number of chunks that depends on 2 values:

- number of lines (transactions) that contains the original one

- the number of lines we want each chunk to contain

While the first value cannot be controlled, the second can be parameterized with Spring and modified at the infrastructure level.

The line threshold, therefore, must no longer be encoded in the class but retrieved from the application.yml.

Configure the threshold via infrastructure configmap.
#### List of Changes

<!--- Describe your changes in detail -->
- Line threshold is moved inside application.yml .
- Tests are adapted.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Parameterize the threshold makes issuing its change easy and dynamic.
Now the value is part of the infrastructure.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.