### PR TITLE
[CEN-1519] Integration of blob splitter in event handling

### DIFF
--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandler.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandler.java
@@ -3,6 +3,7 @@ package it.gov.pagopa.rtd.ms.rtdmsdecrypter.event;
 import it.gov.pagopa.rtd.ms.rtdmsdecrypter.model.BlobApplicationAware;
 import it.gov.pagopa.rtd.ms.rtdmsdecrypter.model.EventGridEvent;
 import it.gov.pagopa.rtd.ms.rtdmsdecrypter.service.BlobRestConnectorImpl;
+import it.gov.pagopa.rtd.ms.rtdmsdecrypter.service.BlobSplitterImpl;
 import it.gov.pagopa.rtd.ms.rtdmsdecrypter.service.DecrypterImpl;
 import java.util.List;
 import java.util.function.Consumer;
@@ -23,12 +24,13 @@ public class EventHandler {
    * Constructor.
    *
    * @param decrypterImpl         an instance of a Decrypter
-   * @param blobRestConnectorImpl an instance of a blobRestConnector
+   * @param blobRestConnectorImpl an instance of a BlobRestConnector
+   * @param blobSplitterImpl      an instance of a BlobSplitter
    * @return a consumer for Event Grid events
    */
   @Bean
   public Consumer<Message<List<EventGridEvent>>> blobStorageConsumer(DecrypterImpl decrypterImpl,
-      BlobRestConnectorImpl blobRestConnectorImpl) {
+      BlobRestConnectorImpl blobRestConnectorImpl, BlobSplitterImpl blobSplitterImpl) {
 
     return message -> message.getPayload().stream()
         .filter(e -> "Microsoft.Storage.BlobCreated".equals(e.getEventType()))
@@ -39,6 +41,8 @@ public class EventHandler {
         .filter(b -> BlobApplicationAware.Status.DOWNLOADED.equals(b.getStatus()))
         .map(decrypterImpl::decrypt)
         .filter(b -> BlobApplicationAware.Status.DECRYPTED.equals(b.getStatus()))
+        .flatMap(blobSplitterImpl::split)
+        .filter(b -> BlobApplicationAware.Status.SPLIT.equals(b.getStatus()))
         .map(blobRestConnectorImpl::put)
         .filter(b -> BlobApplicationAware.Status.UPLOADED.equals(b.getStatus()))
         .map(BlobApplicationAware::localCleanup)

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
@@ -36,6 +36,7 @@ public class BlobApplicationAware {
     RECEIVED,
     DOWNLOADED,
     DECRYPTED,
+    SPLIT,
     UPLOADED,
     DELETED
   }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobRestConnectorImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobRestConnectorImpl.java
@@ -42,7 +42,7 @@ public class BlobRestConnectorImpl implements BlobRestConnector {
   CloseableHttpClient httpClient;
 
   /**
-   * Constructor.
+   * Method that allows the download of the blob from a remote storage.
    *
    * @param blob a blob that has been received but not downloaded
    * @return a locally available blob

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobSplitterImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobSplitterImpl.java
@@ -29,7 +29,7 @@ public class BlobSplitterImpl implements BlobSplitter {
   private int lineThreshold;
 
   /**
-   * Method that spli the content of a blob in chunks of n lines.
+   * Method that split the content of a blob in chunks of n lines.
    *
    * @param blob to be split.
    * @return a list of blobs that represent the split blob.

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobSplitterImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobSplitterImpl.java
@@ -1,5 +1,7 @@
 package it.gov.pagopa.rtd.ms.rtdmsdecrypter.service;
 
+import static it.gov.pagopa.rtd.ms.rtdmsdecrypter.model.BlobApplicationAware.Status.SPLIT;
+
 import it.gov.pagopa.rtd.ms.rtdmsdecrypter.model.BlobApplicationAware;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -36,7 +38,7 @@ public class BlobSplitterImpl implements BlobSplitter {
    */
   public Stream<BlobApplicationAware> split(BlobApplicationAware blob) {
     String blobPath = Path.of(blob.getTargetDir(), blob.getBlob() + ".decrypted").toString();
-
+    lineThreshold = 1;
     ArrayList<BlobApplicationAware> blobSplit = new ArrayList<>();
 
     //Incremental integer for chunk numbering
@@ -65,6 +67,7 @@ public class BlobSplitterImpl implements BlobSplitter {
           }
           BlobApplicationAware tmpBlob = new BlobApplicationAware(
               blob.getBlobUri() + "." + chunkNum);
+          tmpBlob.setStatus(SPLIT);
           blobSplit.add(tmpBlob);
         }
         chunkNum++;

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobSplitterImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobSplitterImpl.java
@@ -38,7 +38,7 @@ public class BlobSplitterImpl implements BlobSplitter {
    */
   public Stream<BlobApplicationAware> split(BlobApplicationAware blob) {
     String blobPath = Path.of(blob.getTargetDir(), blob.getBlob() + ".decrypted").toString();
-    lineThreshold = 1;
+
     ArrayList<BlobApplicationAware> blobSplit = new ArrayList<>();
 
     //Incremental integer for chunk numbering

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/RtdMsDecrypterApplicationTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/RtdMsDecrypterApplicationTest.java
@@ -61,7 +61,7 @@ class RtdMsDecrypterApplicationTest {
   private final String myEventType = "Microsoft.Storage.BlobCreated";
 
   @Test
-  void myshouldConsumeMessageAndCallDecrypter() {
+  void shouldConsumeMessageAndCallDecrypter() {
 
     EventGridEvent my_event = new EventGridEvent();
     my_event.setId(myID);

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/RtdMsDecrypterApplicationTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/RtdMsDecrypterApplicationTest.java
@@ -13,13 +13,16 @@ import it.gov.pagopa.rtd.ms.rtdmsdecrypter.model.BlobApplicationAware;
 import it.gov.pagopa.rtd.ms.rtdmsdecrypter.model.BlobApplicationAware.Status;
 import it.gov.pagopa.rtd.ms.rtdmsdecrypter.model.EventGridEvent;
 import it.gov.pagopa.rtd.ms.rtdmsdecrypter.service.BlobRestConnectorImpl;
+import it.gov.pagopa.rtd.ms.rtdmsdecrypter.service.BlobSplitterImpl;
 import it.gov.pagopa.rtd.ms.rtdmsdecrypter.service.DecrypterImpl;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
@@ -37,6 +40,9 @@ import org.springframework.test.context.ActiveProfiles;
 @ExtendWith(OutputCaptureExtension.class)
 class RtdMsDecrypterApplicationTest {
 
+  @Value("${decrypt.resources.base.path}")
+  String resources;
+
   @MockBean
   DecrypterImpl decrypterImpl;
 
@@ -48,6 +54,9 @@ class RtdMsDecrypterApplicationTest {
 
   @MockBean
   BlobApplicationAware blobApplicationAware;
+
+  @MockBean
+  BlobSplitterImpl blobSplitterImpl;
 
   @Autowired
   private DirectWithAttributesChannel channel;
@@ -71,19 +80,29 @@ class RtdMsDecrypterApplicationTest {
     List<EventGridEvent> my_list = new ArrayList<EventGridEvent>();
     my_list.add(my_event);
 
-    //Mock every step of the blob handling
+    //Prepare fake blobs
     BlobApplicationAware blobDownloaded = new BlobApplicationAware(blobUri);
     BlobApplicationAware blobDecrypted = new BlobApplicationAware(blobUri);
+    BlobApplicationAware blobSplit0 = new BlobApplicationAware(blobUri + ".0");
+    BlobApplicationAware blobSplit1 = new BlobApplicationAware(blobUri + ".1");
+    BlobApplicationAware blobSplit2 = new BlobApplicationAware(blobUri + ".2");
     BlobApplicationAware blobUploaded = new BlobApplicationAware(blobUri);
     BlobApplicationAware blobDeleted = new BlobApplicationAware(blobUri);
 
+    //Mock every step of the blob handling
     blobDownloaded.setStatus(BlobApplicationAware.Status.DOWNLOADED);
     blobDecrypted.setStatus(BlobApplicationAware.Status.DECRYPTED);
+    blobSplit0.setStatus(BlobApplicationAware.Status.SPLIT);
+    blobSplit1.setStatus(BlobApplicationAware.Status.SPLIT);
+    blobSplit2.setStatus(BlobApplicationAware.Status.SPLIT);
     blobUploaded.setStatus(BlobApplicationAware.Status.UPLOADED);
     blobDeleted.setStatus(BlobApplicationAware.Status.DELETED);
 
+    //Mock the behaviour of the beans
     doReturn(blobDownloaded).when(blobRestConnectorImpl).get(any(BlobApplicationAware.class));
     doReturn(blobDecrypted).when(decrypterImpl).decrypt(any(BlobApplicationAware.class));
+    doReturn(Stream.of(blobSplit0, blobSplit1, blobSplit2)).when(blobSplitterImpl)
+        .split(any(BlobApplicationAware.class));
     doReturn(blobApplicationAware).when(blobRestConnectorImpl).put(any(BlobApplicationAware.class));
 
     //Mock of the interested blob's methods
@@ -92,14 +111,16 @@ class RtdMsDecrypterApplicationTest {
 
     await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
 
+      //Send the message to the event grid
       channel.send(MessageBuilder.withPayload(my_list).build());
 
-      // decrypt() is an inner call. Check first
+      //Verify if every handling step is called the desired number of time
       verify(blobRestConnectorImpl, times(1)).get(any());
       verify(decrypterImpl, times(1)).decrypt(any());
-      verify(blobRestConnectorImpl, times(1)).put(any());
-      verify(blobApplicationAware, times(1)).localCleanup();
-      verify(handler, times(1)).blobStorageConsumer(any(), any());
+      verify(blobSplitterImpl, times(1)).split(any());
+      verify(blobRestConnectorImpl, times(3)).put(any());
+      verify(blobApplicationAware, times(3)).localCleanup();
+      verify(handler, times(1)).blobStorageConsumer(any(), any(), any());
 
     });
   }
@@ -111,22 +132,28 @@ class RtdMsDecrypterApplicationTest {
     my_event.setId(myID);
     my_event.setTopic(myTopic);
     my_event.setEventType(myEventType);
+
+    //Set wrong blob name
     my_event.setSubject("/blobServices/default/containers/" + container
         + "/blobs/STAR.99910.TRNLOG.20220228.103107.001.csv.pgp");
+
     List<EventGridEvent> my_list = new ArrayList<EventGridEvent>();
     my_list.add(my_event);
 
     await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
 
+      //Send the message to the event grid
       channel.send(MessageBuilder.withPayload(my_list).build());
 
-      // decrypt() is an inner call. Check first
+      //Verify if every handling step is called the desired number of time
       verify(blobRestConnectorImpl, times(0)).get(any());
       verify(decrypterImpl, times(0)).decrypt(any());
+      verify(blobSplitterImpl, times(0)).split(any());
       verify(blobRestConnectorImpl, times(0)).put(any());
       verify(blobApplicationAware, times(0)).localCleanup();
-      verify(handler, times(1)).blobStorageConsumer(any(), any());
+      verify(handler, times(1)).blobStorageConsumer(any(), any(), any());
       assertThat(output.getOut(), containsString("Wrong name format:"));
+
     });
   }
 
@@ -141,20 +168,29 @@ class RtdMsDecrypterApplicationTest {
     List<EventGridEvent> my_list = new ArrayList<EventGridEvent>();
     my_list.add(my_event);
 
+    //Prepare fake blob
     BlobApplicationAware blobReceived = new BlobApplicationAware(blobUri);
+
+    //Mock desired step of the blob handling
+    //Keep the RECEIVED status, this will trigger the filter
     blobReceived.setStatus(BlobApplicationAware.Status.RECEIVED);
+
+    //Mock the behaviour of the bean
     doReturn(blobReceived).when(blobRestConnectorImpl).get(any(BlobApplicationAware.class));
 
     await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
 
+      //Send the message to the event grid
       channel.send(MessageBuilder.withPayload(my_list).build());
 
-      // decrypt() is an inner call. Check first
+      //Verify if every handling step is called the desired number of time
       verify(blobRestConnectorImpl, times(1)).get(any());
       verify(decrypterImpl, times(0)).decrypt(any());
+      verify(blobSplitterImpl, times(0)).split(any());
       verify(blobRestConnectorImpl, times(0)).put(any());
       verify(blobApplicationAware, times(0)).localCleanup();
-      verify(handler, times(1)).blobStorageConsumer(any(), any());
+      verify(handler, times(1)).blobStorageConsumer(any(), any(), any());
+
     });
   }
 
@@ -169,21 +205,72 @@ class RtdMsDecrypterApplicationTest {
     List<EventGridEvent> my_list = new ArrayList<EventGridEvent>();
     my_list.add(my_event);
 
+    //Prepare fake blob
     BlobApplicationAware blobDownloaded = new BlobApplicationAware(blobUri);
+    BlobApplicationAware blobDecrypted = new BlobApplicationAware(blobUri);
+
+    //Mock desired step of the blob handling
     blobDownloaded.setStatus(BlobApplicationAware.Status.DOWNLOADED);
+    //Keep the DOWNLOADED status, this will trigger the filter
+    blobDecrypted.setStatus(BlobApplicationAware.Status.DOWNLOADED);
+
+    //Mock the behaviour of the beans
     doReturn(blobDownloaded).when(blobRestConnectorImpl).get(any(BlobApplicationAware.class));
-    doReturn(blobDownloaded).when(decrypterImpl).decrypt(any(BlobApplicationAware.class));
+    doReturn(blobDecrypted).when(decrypterImpl).decrypt(any(BlobApplicationAware.class));
 
     await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
 
+      //Send the message to the event grid
       channel.send(MessageBuilder.withPayload(my_list).build());
 
-      // decrypt() is an inner call. Check first
+      //Verify if every handling step is called the desired number of time
+      verify(blobRestConnectorImpl, times(1)).get(any());
+      verify(decrypterImpl, times(1)).decrypt(any());
+      verify(blobSplitterImpl, times(0)).split(any());
+      verify(blobRestConnectorImpl, times(0)).put(any());
+      verify(blobApplicationAware, times(0)).localCleanup();
+      verify(handler, times(1)).blobStorageConsumer(any(), any(), any());
+
+    });
+  }
+
+  @Test
+  void shouldFilterMessageForFailedSplit() {
+
+    EventGridEvent my_event = new EventGridEvent();
+    my_event.setId(myID);
+    my_event.setTopic(myTopic);
+    my_event.setEventType(myEventType);
+    my_event.setSubject(blobUri);
+    List<EventGridEvent> my_list = new ArrayList<EventGridEvent>();
+    my_list.add(my_event);
+
+    //Prepare fake blobs
+    BlobApplicationAware blobDownloaded = new BlobApplicationAware(blobUri);
+    BlobApplicationAware blobDecrypted = new BlobApplicationAware(blobUri);
+    BlobApplicationAware blobSplit = new BlobApplicationAware(blobUri);
+
+    blobDownloaded.setStatus(BlobApplicationAware.Status.DOWNLOADED);
+    blobDecrypted.setStatus(BlobApplicationAware.Status.DECRYPTED);
+    //Keep the DECRYPTED status, this will trigger the filter
+    blobSplit.setStatus(BlobApplicationAware.Status.DECRYPTED);
+
+    //Mock desired step of the blob handling
+    doReturn(blobDownloaded).when(blobRestConnectorImpl).get(any(BlobApplicationAware.class));
+    doReturn(blobDecrypted).when(decrypterImpl).decrypt(any(BlobApplicationAware.class));
+    doReturn(Stream.of(blobSplit)).when(blobSplitterImpl).split(any(BlobApplicationAware.class));
+
+    await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+
+      //Send the message to the event grid
+      channel.send(MessageBuilder.withPayload(my_list).build());
+
+      //Verify if every handling step is called the desired number of time
       verify(blobRestConnectorImpl, times(1)).get(any());
       verify(decrypterImpl, times(1)).decrypt(any());
       verify(blobRestConnectorImpl, times(0)).put(any());
       verify(blobApplicationAware, times(0)).localCleanup();
-      verify(handler, times(1)).blobStorageConsumer(any(), any());
+      verify(handler, times(1)).blobStorageConsumer(any(), any(), any());
     });
   }
 
@@ -198,24 +285,42 @@ class RtdMsDecrypterApplicationTest {
     List<EventGridEvent> my_list = new ArrayList<EventGridEvent>();
     my_list.add(my_event);
 
+    //Prepare fake blobs
     BlobApplicationAware blobDownloaded = new BlobApplicationAware(blobUri);
     BlobApplicationAware blobDecrypted = new BlobApplicationAware(blobUri);
+    BlobApplicationAware blobSplit0 = new BlobApplicationAware(blobUri + ".0");
+    BlobApplicationAware blobSplit1 = new BlobApplicationAware(blobUri + ".1");
+    BlobApplicationAware blobSplit2 = new BlobApplicationAware(blobUri + ".2");
+    BlobApplicationAware blobUploaded = new BlobApplicationAware(blobUri);
+
+    //Mock every step of the blob handling
     blobDownloaded.setStatus(BlobApplicationAware.Status.DOWNLOADED);
     blobDecrypted.setStatus(BlobApplicationAware.Status.DECRYPTED);
+    blobSplit0.setStatus(BlobApplicationAware.Status.SPLIT);
+    blobSplit1.setStatus(BlobApplicationAware.Status.SPLIT);
+    blobSplit2.setStatus(BlobApplicationAware.Status.SPLIT);
+    //Keep the SPLIT status, this will trigger the filter
+    blobUploaded.setStatus(BlobApplicationAware.Status.SPLIT);
+
+    //Mock the behaviour of the beans
     doReturn(blobDownloaded).when(blobRestConnectorImpl).get(any(BlobApplicationAware.class));
     doReturn(blobDecrypted).when(decrypterImpl).decrypt(any(BlobApplicationAware.class));
-    doReturn(blobDecrypted).when(blobRestConnectorImpl).put(any(BlobApplicationAware.class));
+    doReturn(Stream.of(blobSplit0, blobSplit1, blobSplit2)).when(blobSplitterImpl)
+        .split(any(BlobApplicationAware.class));
+    doReturn(blobUploaded).when(blobRestConnectorImpl).put(any(BlobApplicationAware.class));
 
     await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
 
+      //Send the message to the event grid
       channel.send(MessageBuilder.withPayload(my_list).build());
 
-      // decrypt() is an inner call. Check first
+      //Verify if every handling step is called the desired number of time
       verify(blobRestConnectorImpl, times(1)).get(any());
       verify(decrypterImpl, times(1)).decrypt(any());
-      verify(blobRestConnectorImpl, times(1)).put(any());
+      verify(blobRestConnectorImpl, times(3)).put(any());
       verify(blobApplicationAware, times(0)).localCleanup();
-      verify(handler, times(1)).blobStorageConsumer(any(), any());
+      verify(handler, times(1)).blobStorageConsumer(any(), any(), any());
+
     });
   }
 }


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR integrates the splitting step in the event handler.
After the decryption, every blob chunk is split and uploaded separately.

A filter between split and put is inserted in order to prevent uploading file that failed the split step.

#### List of Changes

<!--- Describe your changes in detail -->
- The split step is added to the event handler.
- The split status is added to the BlobApplicationAware class.
- The integration tests on the handler are update accordingly.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The split mechanism was standalone. Once tested with unit tests it is ready to be inserted among event handling steps.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [x] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.