### PR TITLE
[CEN-1596] Avoid deletion of unhandled chunks

### DIFF
--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
@@ -163,16 +163,28 @@ public class BlobApplicationAware {
    */
   public BlobApplicationAware localCleanup() {
 
-    for (File f : Objects.requireNonNull(Path.of(this.targetDir).toFile().listFiles())) {
-      //Delete every file in the temporary directory that starts with the name of the original blob.
-      // This includes the blob itself, its decryption and all the chunks.
-      if (f.getName().startsWith(originalBlobName)) {
-        try {
-          Files.delete(f.toPath());
-        } catch (Exception e) {
-          log.warn(FAIL_FILE_DELETE_WARNING_MSG + f.getName() + " (" + e + ")");
-        }
+    File tmpFile = Path.of(targetDir, blob).toFile();
+
+    try {
+      //Delete the chunk
+      if (tmpFile.exists()) {
+        Files.delete(tmpFile.toPath());
       }
+
+      //Delete the original encrypted file (if present)
+      tmpFile = Path.of(this.targetDir, originalBlobName).toFile();
+      if (tmpFile.exists()) {
+        Files.delete(tmpFile.toPath());
+      }
+
+      //Delete the original decrypted file (if present)l
+      tmpFile = Path.of(this.targetDir, originalBlobName + ".decrypted").toFile();
+      if (tmpFile.exists()) {
+        Files.delete(tmpFile.toPath());
+      }
+
+    } catch (Exception e) {
+      log.warn(FAIL_FILE_DELETE_WARNING_MSG + tmpFile.getName() + " (" + e + ")");
     }
 
     status = Status.DELETED;

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
@@ -177,7 +177,7 @@ public class BlobApplicationAware {
         Files.delete(tmpFile.toPath());
       }
 
-      //Delete the original decrypted file (if present)l
+      //Delete the original decrypted file (if present)
       tmpFile = Path.of(this.targetDir, originalBlobName + ".decrypted").toFile();
       if (tmpFile.exists()) {
         Files.delete(tmpFile.toPath());

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobSplitterTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobSplitterTest.java
@@ -11,6 +11,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -73,7 +74,15 @@ class BlobSplitterTest {
 
     blobSplitterImpl.setLineThreshold(1);
 
-    assertEquals(3, blobSplitterImpl.split(fakeBlob).count());
+    Stream<BlobApplicationAware> chunks = blobSplitterImpl.split(fakeBlob);
+    Iterable<BlobApplicationAware> iterable = chunks::iterator;
+    int i = 0;
+    for (BlobApplicationAware b : iterable) {
+      assertEquals(Status.SPLIT, b.getStatus());
+      assertEquals(blobName + "." + i + ".decrypted", b.getBlob());
+      i++;
+    }
+    assertEquals(3, i);
     assertThat(output.getOut(), containsString("Obtained 3 chunk/s from blob:"));
 
   }
@@ -85,13 +94,21 @@ class BlobSplitterTest {
 
     blobSplitterImpl.setLineThreshold(2);
 
-    assertEquals(2, blobSplitterImpl.split(fakeBlob).count());
+    Stream<BlobApplicationAware> chunks = blobSplitterImpl.split(fakeBlob);
+    Iterable<BlobApplicationAware> iterable = chunks::iterator;
+    int i = 0;
+    for (BlobApplicationAware b : iterable) {
+      assertEquals(Status.SPLIT, b.getStatus());
+      assertEquals(blobName + "." + i + ".decrypted", b.getBlob());
+      i++;
+    }
+    assertEquals(2, i);
     assertThat(output.getOut(), containsString("Obtained 2 chunk/s from blob:"));
 
   }
 
   @Test
-  void shouldNotSplitMissingFile(CapturedOutput output) throws IOException {
+  void shouldNotSplitMissingFile(CapturedOutput output) {
 
     //Set the wrong directory for locating the decrypted fake blob
     fakeBlob.setTargetDir(resources);


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes a new cleanup routine that avoids the deletion of sibling chunks that are not handled yet by the event handler.
#### List of Changes

<!--- Describe your changes in detail -->
- New local cleanup routine.
- Improved cleanup test.
- Improved split test. 
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Given the functional nature of the event handler, one chunk reaches the end of the handling steps and deletes all the other chunk files, before they even continue the process.
This lead to file not found exception.
This change makes the chunk delete only itself, the original pgp file (if present) and the decrypted one (if present).
#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.