### PR TITLE
[RTD-118] Rename line splitting variable name

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ decrypt:
       rtd: rtd-transactions-decrypted
       ade: ade-transactions-decrypted
   splitter:
-    threshold: ${LINE_SPLITTING_THRESHOLD:10000}
+    threshold: ${SPLITTER_LINE_THRESHOLD:10000}
 ---
 spring:
   config:


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR fix a bug on line splitting variable name in application properties.
#### List of Changes
<!--- Describe your changes in detail -->
- rename the expected name as the one specified in config map.
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This bug led to pick the default value for line splitting (10000) instead of the one set in config map.
#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [x] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.