### PR TITLE
[RTD-236] Tuning Kafka Consumer

### DIFF
--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandler.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandler.java
@@ -47,16 +47,16 @@ public class EventHandler {
         .map(BlobApplicationAware::new)
         .filter(b -> !BlobApplicationAware.Application.NOAPP.equals(b.getApp()))
         .map(blobRestConnectorImpl::get)
-        .filter(b -> BlobApplicationAware.Status.DOWNLOADED.equals(b.getStatus()))
-        .map(decrypterImpl::decrypt)
-        .filter(b -> BlobApplicationAware.Status.DECRYPTED.equals(b.getStatus()))
-        .flatMap(blobSplitterImpl::split)
         .peek(b -> {
           if (!isChunkUploadEnabled) {
             log.info("Doing fake job...");
             delay(5);
           }
         })
+        .filter(b -> BlobApplicationAware.Status.DOWNLOADED.equals(b.getStatus()))
+        .map(decrypterImpl::decrypt)
+        .filter(b -> BlobApplicationAware.Status.DECRYPTED.equals(b.getStatus()))
+        .flatMap(blobSplitterImpl::split)
         .filter(b -> BlobApplicationAware.Status.SPLIT.equals(b.getStatus()))
         .map(b -> isChunkUploadEnabled ? blobRestConnectorImpl.put(b) : b)
         .filter(b -> BlobApplicationAware.Status.UPLOADED.equals(b.getStatus()))

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandler.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandler.java
@@ -45,7 +45,11 @@ public class EventHandler {
         .filter(e -> "Microsoft.Storage.BlobCreated".equals(e.getEventType()))
         .map(EventGridEvent::getSubject)
         .map(BlobApplicationAware::new)
-        .peek(b -> delay(5))
+        .peek(b -> {
+          if (!isChunkUploadEnabled) {
+            delay(5);
+          }
+        })
         .filter(b -> !BlobApplicationAware.Application.NOAPP.equals(b.getApp()))
         .map(blobRestConnectorImpl::get)
         .filter(b -> BlobApplicationAware.Status.DOWNLOADED.equals(b.getStatus()))

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandler.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandler.java
@@ -47,12 +47,6 @@ public class EventHandler {
         .map(BlobApplicationAware::new)
         .filter(b -> !BlobApplicationAware.Application.NOAPP.equals(b.getApp()))
         .map(blobRestConnectorImpl::get)
-        .peek(b -> {
-          if (!isChunkUploadEnabled) {
-            log.info("Doing fake job...");
-            delay(5);
-          }
-        })
         .filter(b -> BlobApplicationAware.Status.DOWNLOADED.equals(b.getStatus()))
         .map(decrypterImpl::decrypt)
         .filter(b -> BlobApplicationAware.Status.DECRYPTED.equals(b.getStatus()))
@@ -63,13 +57,5 @@ public class EventHandler {
         .map(BlobApplicationAware::localCleanup)
         .filter(b -> BlobApplicationAware.Status.DELETED.equals(b.getStatus()))
         .collect(Collectors.toList());
-  }
-
-  private void delay(int minutes) {
-    try {
-      Thread.sleep((long) minutes * 60 * 1000);
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e);
-    }
   }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandler.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandler.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,6 +20,7 @@ import org.springframework.messaging.Message;
  */
 @Configuration
 @Getter
+@Slf4j
 public class EventHandler {
 
   @Value("${decrypt.enableChunkUpload}")
@@ -35,6 +37,8 @@ public class EventHandler {
   @Bean
   public Consumer<Message<List<EventGridEvent>>> blobStorageConsumer(DecrypterImpl decrypterImpl,
       BlobRestConnectorImpl blobRestConnectorImpl, BlobSplitterImpl blobSplitterImpl) {
+
+    log.info("Chunks upload enabled: {}", isChunkUploadEnabled);
 
     return message -> message.getPayload().stream()
         .filter(e -> "Microsoft.Storage.BlobCreated".equals(e.getEventType()))

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandler.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandler.java
@@ -6,6 +6,7 @@ import it.gov.pagopa.rtd.ms.rtdmsdecrypter.service.BlobRestConnectorImpl;
 import it.gov.pagopa.rtd.ms.rtdmsdecrypter.service.BlobSplitterImpl;
 import it.gov.pagopa.rtd.ms.rtdmsdecrypter.service.DecrypterImpl;
 import java.util.List;
+import java.util.Random;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import lombok.Getter;
@@ -44,6 +45,7 @@ public class EventHandler {
         .filter(e -> "Microsoft.Storage.BlobCreated".equals(e.getEventType()))
         .map(EventGridEvent::getSubject)
         .map(BlobApplicationAware::new)
+        .peek(b -> delay(5))
         .filter(b -> !BlobApplicationAware.Application.NOAPP.equals(b.getApp()))
         .map(blobRestConnectorImpl::get)
         .filter(b -> BlobApplicationAware.Status.DOWNLOADED.equals(b.getStatus()))
@@ -58,4 +60,11 @@ public class EventHandler {
         .collect(Collectors.toList());
   }
 
+  private void delay(int minutes) {
+    try {
+      Thread.sleep((long) minutes * 60 * 1000);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandler.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandler.java
@@ -6,7 +6,6 @@ import it.gov.pagopa.rtd.ms.rtdmsdecrypter.service.BlobRestConnectorImpl;
 import it.gov.pagopa.rtd.ms.rtdmsdecrypter.service.BlobSplitterImpl;
 import it.gov.pagopa.rtd.ms.rtdmsdecrypter.service.DecrypterImpl;
 import java.util.List;
-import java.util.Random;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import lombok.Getter;

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
@@ -162,6 +162,7 @@ public class BlobApplicationAware {
    * @return the blob with its status set to deleted.
    */
   public BlobApplicationAware localCleanup() {
+    log.info("Start deleting locally blob {}", blob);
 
     File tmpFile = Path.of(targetDir, blob).toFile();
 
@@ -188,6 +189,8 @@ public class BlobApplicationAware {
     }
 
     status = Status.DELETED;
+
+    log.info("Deleted locally blob {}", blob);
     return this;
 
   }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobRestConnectorImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobRestConnectorImpl.java
@@ -48,6 +48,7 @@ public class BlobRestConnectorImpl implements BlobRestConnector {
    * @return a locally available blob
    */
   public BlobApplicationAware get(BlobApplicationAware blob) {
+    log.info("Start GET blob {} from {}", blob.getBlob(), blob.getContainer());
 
     String uri = baseUrl + "/" + blobBasePath + "/" + blob.getContainer() + "/" + blob.getBlob();
     final HttpGet getBlob = new HttpGet(uri);
@@ -75,6 +76,7 @@ public class BlobRestConnectorImpl implements BlobRestConnector {
    * @return an uploaded blob
    */
   public BlobApplicationAware put(BlobApplicationAware blob) {
+    log.info("Start PUT blob {} to {}", blob.getBlob(), blob.getTargetContainer());
 
     String uri =
         baseUrl + "/" + blobBasePath + "/" + blob.getTargetContainer() + "/" + blob.getBlob();

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobSplitterImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobSplitterImpl.java
@@ -39,6 +39,8 @@ public class BlobSplitterImpl implements BlobSplitter {
    * @return a list of blobs that represent the split blob.
    */
   public Stream<BlobApplicationAware> split(BlobApplicationAware blob) {
+    log.info("Start splitting blob {} from {}", blob.getBlob(), blob.getContainer());
+
     String blobPath = Path.of(blob.getTargetDir(), blob.getBlob() + decryptedSuffix).toString();
 
     ArrayList<BlobApplicationAware> blobSplit = new ArrayList<>();
@@ -97,7 +99,11 @@ public class BlobSplitterImpl implements BlobSplitter {
 
     if (!failSplit) {
       log.info("Obtained {} chunk/s from blob:{}", chunkNum, blob.getBlob());
+      return blobSplit.stream();
+    } else {
+      // If split fails, return the original blob (without the SPLIT status)
+      log.info("Failed splitting blob:{}", blob.getBlob());
+      return Stream.of(blob);
     }
-    return blobSplit.stream();
   }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/DecrypterImpl.java
@@ -66,6 +66,7 @@ public class DecrypterImpl implements Decrypter {
    * @return an unencrypted blob
    */
   public BlobApplicationAware decrypt(BlobApplicationAware blob) {
+    log.info("Start decrypt blob: {}", blob.getBlob());
 
     boolean decryptFailed = false;
     try (
@@ -82,10 +83,7 @@ public class DecrypterImpl implements Decrypter {
     } catch (IllegalArgumentException e) {
       log.warn("{}: {}", e.getMessage(), blob.getBlob());
       decryptFailed = true;
-    } catch (PGPException e) {
-      log.error("Cannot decrypt {}: {}", blob.getBlob(), e.getMessage());
-      decryptFailed = true;
-    } catch (IOException e) {
+    } catch (PGPException | IOException e) {
       log.error("Cannot decrypt {}: {}", blob.getBlob(), e.getMessage());
       decryptFailed = true;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ decrypt:
       rtd: rtd-transactions-decrypted
       ade: ade-transactions-decrypted
   splitter:
-    threshold: ${SPLITTER_LINE_THRESHOLD:10000}
+    threshold: ${SPLITTER_LINE_THRESHOLD:250000}
   enableChunkUpload: ${ENABLE_CHUNK_UPLOAD:false}
 ---
 spring:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,6 +60,8 @@ spring:
           auto-create-topics: false
           brokers: ${KAFKA_BROKER}
           configuration:
+            max.poll.interval.ms: 300000 # e.g. 5 min
+            max.poll.records: 1
             sasl:
               jaas:
                 config: ${KAFKA_SASL_JAAS_CONFIG_CONSUMER_BLOB_STORAGE_EVENTS}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,7 +60,7 @@ spring:
           auto-create-topics: false
           brokers: ${KAFKA_BROKER}
           configuration:
-            max.poll.interval.ms: 600000 # e.g. 10 min
+            max.poll.interval.ms: 600000 # 10 min
             max.poll.records: 1
             sasl:
               jaas:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,7 @@ decrypt:
       ade: ade-transactions-decrypted
   splitter:
     threshold: ${SPLITTER_LINE_THRESHOLD:10000}
+  enableChunkUpload: ${ENABLE_CHUNK_UPLOAD:false}
 ---
 spring:
   config:
@@ -33,7 +34,6 @@ spring:
           group: rtd-decrypter-consumer-group
           content-type: application/json
           binder: kafka
-
       kafka:
         binder:
           auto-create-topics: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,7 +60,7 @@ spring:
           auto-create-topics: false
           brokers: ${KAFKA_BROKER}
           configuration:
-            max.poll.interval.ms: 300000 # e.g. 5 min
+            max.poll.interval.ms: 600000 # e.g. 10 min
             max.poll.records: 1
             sasl:
               jaas:

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/RtdMsDecrypterApplicationTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/RtdMsDecrypterApplicationTest.java
@@ -33,12 +33,16 @@ import org.springframework.cloud.stream.messaging.DirectWithAttributesChannel;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
 @ActiveProfiles("test")
 @EmbeddedKafka(topics = {
     "rtd-platform-events"}, partitions = 1, bootstrapServersProperty = "spring.cloud.stream.kafka.binder.brokers")
 @ExtendWith(OutputCaptureExtension.class)
+@TestPropertySource(properties = {
+    "decrypt.enableChunkUpload=true",
+})
 class RtdMsDecrypterApplicationTest {
 
   @Value("${decrypt.resources.base.path}")

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandlerTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandlerTest.java
@@ -32,6 +32,7 @@ import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
 
 @SpringBootTest
@@ -39,6 +40,9 @@ import org.springframework.test.context.ActiveProfiles;
     "rtd-platform-events"}, partitions = 1, bootstrapServersProperty = "spring.cloud.stream.kafka.binder.brokers")
 @ActiveProfiles("test")
 @ExtendWith(OutputCaptureExtension.class)
+@TestPropertySource(properties = {
+    "decrypt.enableChunkUpload=true",
+})
 class EventHandlerTest {
 
 


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR fix kafka consumer timeout and add a new variable to enable/disable the upload process to Azure Blob Storage

#### List of Changes
- fixed kafka timeout consumer by using `max.poll.interval.ms` and `max.poll.records` consumer's properties. The first one is set to 10 minutes, while the second one to `1`. In this way the consumer process one event at time and has 10 minutes of to complete is work.

- introduced a new application property `enableChunkUpload` which allow to disable/enable the upload of chunks to blobstorage. Also, this property can be set by `ENABLE_CHUNK_UPLOAD` environment variable. If not set the default is `false`.

- logging improved
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [x] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.