### PR TITLE
[RTD-302] Allow to set kafka consumer timeout by environment variable

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,7 +60,7 @@ spring:
           auto-create-topics: false
           brokers: ${KAFKA_BROKER}
           configuration:
-            max.poll.interval.ms: 600000 # 10 min
+            max.poll.interval.ms: ${CONSUMER_TIMEOUT_MS:600000} # default to 10 min
             max.poll.records: 1
             sasl:
               jaas:


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR add ability to set a kafka consumer timeout (`max.poll.interval.ms`) by environment variable `CONSUMER_TIMEOUT_MS`. If not set default to 10 minutes.

#### List of Changes

- `max.poll.interval.ms` can be set by `CONSUMER_TIMEOUT_MS` environment variable or default to 10 minutes.

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.