### PR TITLE
[RTD-599] Validate stream of records

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ COPY --from=buildtime /build/target/*.jar /app/app.jar
 # The agent is enabled at runtime via JAVA_TOOL_OPTIONS.
 ADD https://github.com/microsoft/ApplicationInsights-Java/releases/download/3.2.7/applicationinsights-agent-3.2.7.jar /app/applicationinsights-agent.jar
 
-ENTRYPOINT ["java","-jar","/app/app.jar"]
+ENTRYPOINT ["java","-Xmx4g","-jar","/app/app.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,11 @@
       <artifactId>spring-cloud-function-context</artifactId>
       <version>3.2.7</version>
     </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>1.32</version>
+    </dependency>
     <!--    END VERSION OVERRIDE-->
   </dependencies>
   <dependencyManagement>

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandler.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandler.java
@@ -62,17 +62,18 @@ public class EventHandler {
           .filter(b -> BlobApplicationAware.Status.VERIFIED.equals(b.getStatus()))
           .collect(Collectors.toList());
 
-      if (verifiedChunks.size() == chunks.size()) {
-        List<BlobApplicationAware> uploadedChunks = verifiedChunks.stream()
-            .map(b -> isChunkUploadEnabled ? blobRestConnectorImpl.put(b) : b)
-            .filter(b -> BlobApplicationAware.Status.UPLOADED.equals(b.getStatus()))
-            .collect(Collectors.toList());
-        log.info("Uploaded chunks: {}", uploadedChunks.size());
-      } else {
-        log.error("Not all chunks are verified, no chunks will be uploaded");
-      }
-
       if (!chunks.isEmpty()) {
+
+        if (verifiedChunks.size() == chunks.size()) {
+          List<BlobApplicationAware> uploadedChunks = verifiedChunks.stream()
+              .map(b -> isChunkUploadEnabled ? blobRestConnectorImpl.put(b) : b)
+              .filter(b -> BlobApplicationAware.Status.UPLOADED.equals(b.getStatus()))
+              .collect(Collectors.toList());
+          log.info("Uploaded chunks: {}", uploadedChunks.size());
+        } else {
+          log.error("Not all chunks are verified, no chunks will be uploaded");
+        }
+
         List<BlobApplicationAware> deletedChunks = chunks.stream()
             .map(BlobApplicationAware::localCleanup)
             .filter(b -> BlobApplicationAware.Status.DELETED.equals(b.getStatus()))
@@ -80,6 +81,7 @@ public class EventHandler {
 
         log.info("Handled blob: {}", deletedChunks.get(0).getOriginalBlobName());
       }
+
     };
   }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandler.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandler.java
@@ -61,11 +61,18 @@ public class EventHandler {
 
       int numberOfVerifiedChunks = verifiedChunks.size();
 
-      List<BlobApplicationAware> handledChunks = verifiedChunks.stream()
+      List<BlobApplicationAware> uploadedChunks = verifiedChunks.stream()
           .filter(b -> b.chunkNumberCheck(numberOfVerifiedChunks))
           .map(b -> isChunkUploadEnabled ? blobRestConnectorImpl.put(b) : b)
           .filter(b -> BlobApplicationAware.Status.UPLOADED.equals(b.getStatus()))
           .map(BlobApplicationAware::localCleanup)
+          .collect(Collectors.toList());
+
+      if (uploadedChunks.size() != numberOfVerifiedChunks) {
+        log.error("Not all chunks are verified, no chunks will be uploaded");
+      }
+
+      List<BlobApplicationAware> handledChunks = verifiedChunks.stream()
           .filter(b -> BlobApplicationAware.Status.DELETED.equals(b.getStatus()))
           .collect(Collectors.toList());
 

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandler.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandler.java
@@ -43,23 +43,31 @@ public class EventHandler {
 
     log.info("Chunks upload enabled: {}", isChunkUploadEnabled);
 
-    return message -> message.getPayload().stream()
-        .filter(e -> "Microsoft.Storage.BlobCreated".equals(e.getEventType()))
-        .map(EventGridEvent::getSubject)
-        .map(BlobApplicationAware::new)
-        .filter(b -> !BlobApplicationAware.Application.NOAPP.equals(b.getApp()))
-        .map(blobRestConnectorImpl::get)
-        .filter(b -> BlobApplicationAware.Status.DOWNLOADED.equals(b.getStatus()))
-        .map(decrypterImpl::decrypt)
-        .filter(b -> BlobApplicationAware.Status.DECRYPTED.equals(b.getStatus()))
-        .flatMap(blobSplitterImpl::split)
-        .filter(b -> BlobApplicationAware.Status.SPLIT.equals(b.getStatus()))
-        .map(blobVerifierImpl::verify)
-        .filter(b -> BlobApplicationAware.Status.VERIFIED.equals(b.getStatus()))
-        .map(b -> isChunkUploadEnabled ? blobRestConnectorImpl.put(b) : b)
-        .filter(b -> BlobApplicationAware.Status.UPLOADED.equals(b.getStatus()))
-        .map(BlobApplicationAware::localCleanup)
-        .filter(b -> BlobApplicationAware.Status.DELETED.equals(b.getStatus()))
-        .collect(Collectors.toList());
+    return message -> {
+      List<BlobApplicationAware> test = message.getPayload().stream()
+          .filter(e -> "Microsoft.Storage.BlobCreated".equals(e.getEventType()))
+          .map(EventGridEvent::getSubject)
+          .map(BlobApplicationAware::new)
+          .filter(b -> !BlobApplicationAware.Application.NOAPP.equals(b.getApp()))
+          .map(blobRestConnectorImpl::get)
+          .filter(b -> BlobApplicationAware.Status.DOWNLOADED.equals(b.getStatus()))
+          .map(decrypterImpl::decrypt)
+          .filter(b -> BlobApplicationAware.Status.DECRYPTED.equals(b.getStatus()))
+          .flatMap(blobSplitterImpl::split)
+          .filter(b -> BlobApplicationAware.Status.SPLIT.equals(b.getStatus()))
+          .map(blobVerifierImpl::verify)
+          .filter(b -> BlobApplicationAware.Status.VERIFIED.equals(b.getStatus()))
+          .collect(Collectors.toList());
+
+      int verifiedChunks = test.size();
+
+      test.stream()
+          .filter(b -> b.chunkNumberCheck(verifiedChunks))
+          .map(b -> isChunkUploadEnabled ? blobRestConnectorImpl.put(b) : b)
+          .filter(b -> BlobApplicationAware.Status.UPLOADED.equals(b.getStatus()))
+          .map(BlobApplicationAware::localCleanup)
+          .filter(b -> BlobApplicationAware.Status.DELETED.equals(b.getStatus()))
+          .collect(Collectors.toList());
+    };
   }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
@@ -58,6 +58,7 @@ public class BlobApplicationAware {
 
   private String flowNumber;
 
+  private Integer origianalFileChunksNumber;
 
   private String targetContainerAde = "ade-transactions-decrypted";
   private String targetContainerRtd = "rtd-transactions-decrypted";
@@ -212,6 +213,10 @@ public class BlobApplicationAware {
     log.info("Deleted locally blob {}", blob);
     return this;
 
+  }
+
+  public boolean chunkNumberCheck(Integer chunkNumber) {
+    return (chunkNumber.equals(origianalFileChunksNumber));
   }
 }
   

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/BlobApplicationAware.java
@@ -215,9 +215,6 @@ public class BlobApplicationAware {
 
   }
 
-  public boolean chunkNumberCheck(Integer chunkNumber) {
-    return (chunkNumber.equals(origianalFileChunksNumber));
-  }
 }
   
 

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobSplitterImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobSplitterImpl.java
@@ -2,24 +2,16 @@ package it.gov.pagopa.rtd.ms.rtdmsdecrypter.service;
 
 import static it.gov.pagopa.rtd.ms.rtdmsdecrypter.model.BlobApplicationAware.Status.SPLIT;
 
-import com.opencsv.bean.CsvToBeanBuilder;
-import it.gov.pagopa.rtd.ms.rtdmsdecrypter.model.AdeTransactionsAggregate;
 import it.gov.pagopa.rtd.ms.rtdmsdecrypter.model.BlobApplicationAware;
 import it.gov.pagopa.rtd.ms.rtdmsdecrypter.model.BlobApplicationAware.Application;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.StringReader;
 import java.io.Writer;
 import java.nio.channels.Channels;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
-import java.util.Set;
 import java.util.stream.Stream;
-import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
@@ -125,6 +117,9 @@ public class BlobSplitterImpl implements BlobSplitter {
 
     if (!failSplit) {
       log.info("Obtained {} chunk/s from blob:{}", chunkNum, blob.getBlob());
+      for (BlobApplicationAware b : blobSplit) {
+        b.setOrigianalFileChunksNumber(chunkNum);
+      }
       return blobSplit.stream();
     } else {
       // If split fails, return the original blob (without the SPLIT status)

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobSplitterImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobSplitterImpl.java
@@ -135,6 +135,7 @@ public class BlobSplitterImpl implements BlobSplitter {
     } else {
       // If split fails, return the original blob (without the SPLIT status)
       log.info("Failed splitting blob:{}", blob.getBlob());
+      blob.localCleanup();
       return Stream.of(blob);
     }
   }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobVerifierImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobVerifierImpl.java
@@ -90,7 +90,7 @@ public class BlobVerifierImpl implements BlobVerifier {
       blob.localCleanup();
     }
 
-    logVerificationInformation(blob.getOriginalBlobName(), numberOfDeserializeRecords,
+    logVerificationInformation(blob.getBlob(), numberOfDeserializeRecords,
         violations.size());
     return blob;
   }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobVerifierImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobVerifierImpl.java
@@ -5,24 +5,15 @@ import static it.gov.pagopa.rtd.ms.rtdmsdecrypter.model.BlobApplicationAware.Sta
 import com.opencsv.bean.BeanVerifier;
 import com.opencsv.bean.CsvToBean;
 import com.opencsv.bean.CsvToBeanBuilder;
-import com.opencsv.bean.StatefulBeanToCsv;
-import com.opencsv.bean.StatefulBeanToCsvBuilder;
-import com.opencsv.exceptions.CsvDataTypeMismatchException;
 import com.opencsv.exceptions.CsvException;
-import com.opencsv.exceptions.CsvRequiredFieldEmptyException;
 import it.gov.pagopa.rtd.ms.rtdmsdecrypter.config.VerifierFactory;
-import it.gov.pagopa.rtd.ms.rtdmsdecrypter.model.AdeTransactionsAggregate;
 import it.gov.pagopa.rtd.ms.rtdmsdecrypter.model.BlobApplicationAware;
-import it.gov.pagopa.rtd.ms.rtdmsdecrypter.model.BlobApplicationAware.Application;
 import it.gov.pagopa.rtd.ms.rtdmsdecrypter.model.DecryptedRecord;
-import it.gov.pagopa.rtd.ms.rtdmsdecrypter.model.RtdTransaction;
-import java.io.BufferedWriter;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.stream.Stream;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -78,7 +69,9 @@ public class BlobVerifierImpl implements BlobVerifier {
 
     CsvToBean<DecryptedRecord> csvToBean = builder.build();
 
-    List<DecryptedRecord> deserialized = csvToBean.parse();
+    Stream<DecryptedRecord> deserialized = csvToBean.stream();
+
+    long numberOfDeserializeRecords = deserialized.count();
     List<CsvException> violations = csvToBean.getCapturedExceptions();
 
     if (!violations.isEmpty()) {
@@ -86,14 +79,8 @@ public class BlobVerifierImpl implements BlobVerifier {
         log.error("Validation error at line " + e.getLineNumber() + " : " + e.getMessage());
       }
       isValid = false;
-    } else if (deserialized.isEmpty()) {
+    } else if (numberOfDeserializeRecords == 0) {
       log.error("No records found in file {}", blob.getBlob());
-      isValid = false;
-    }
-
-    try {
-      serializeValidRecords(deserialized, blob.getTargetDir(), blob.getBlob());
-    } catch (Exception e) {
       isValid = false;
     }
 
@@ -103,30 +90,14 @@ public class BlobVerifierImpl implements BlobVerifier {
       blob.localCleanup();
     }
 
-    logVerificationInformation(blob.getBlob(), deserialized.size(), violations.size());
+    logVerificationInformation(blob.getOriginalBlobName(), numberOfDeserializeRecords,
+        violations.size());
     return blob;
   }
 
-  private void logVerificationInformation(String blobName, Integer deserializedSize,
+  private void logVerificationInformation(String blobName, Long deserializedSize,
       Integer violations) {
     log.info("END Verifying {} records: {} valid , {} malformed", blobName,
         deserializedSize, violations);
-  }
-
-  private void serializeValidRecords(List<DecryptedRecord> deserialized, String targetDir,
-      String blobName)
-      throws IOException, CsvRequiredFieldEmptyException, CsvDataTypeMismatchException {
-    try (BufferedWriter writer = new BufferedWriter(new FileWriter(
-        Path.of(targetDir, blobName).toFile()))) {
-      StatefulBeanToCsv<DecryptedRecord> beanToCsv = new StatefulBeanToCsvBuilder<DecryptedRecord>(
-          writer)
-          .withSeparator(';')
-          .withApplyQuotesToAll(false)
-          .build();
-      beanToCsv.write(deserialized);
-    } catch (Exception e) {
-      log.error("Error writing to file {}", blobName);
-      throw e;
-    }
   }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobVerifierImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobVerifierImpl.java
@@ -86,8 +86,6 @@ public class BlobVerifierImpl implements BlobVerifier {
 
     if (isValid) {
       blob.setStatus(VERIFIED);
-    } else {
-      blob.localCleanup();
     }
 
     logVerificationInformation(blob.getBlob(), numberOfDeserializeRecords,

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/RtdMsDecrypterApplicationTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/RtdMsDecrypterApplicationTest.java
@@ -135,7 +135,6 @@ class RtdMsDecrypterApplicationTest {
       verify(blobSplitterImpl, times(1)).split(any());
       verify(blobVerifierImpl, times(3)).verify(any());
       verify(blobRestConnectorImpl, times(3)).put(any());
-      verify(blobApplicationAware, times(3)).localCleanup();
       verify(handler, times(1)).blobStorageConsumer(any(), any(), any(), any());
 
     });

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/RtdMsDecrypterApplicationTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/RtdMsDecrypterApplicationTest.java
@@ -28,8 +28,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.boot.test.system.CapturedOutput;
-import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.cloud.stream.messaging.DirectWithAttributesChannel;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.messaging.support.MessageBuilder;
@@ -40,7 +38,6 @@ import org.springframework.test.context.TestPropertySource;
 @ActiveProfiles("test")
 @EmbeddedKafka(topics = {
     "rtd-platform-events"}, partitions = 1, bootstrapServersProperty = "spring.cloud.stream.kafka.binder.brokers")
-@ExtendWith(OutputCaptureExtension.class)
 @TestPropertySource(properties = {
     "decrypt.enableChunkUpload=true",
 })
@@ -145,7 +142,7 @@ class RtdMsDecrypterApplicationTest {
   }
 
   @Test
-  void shouldFilterMessageForWrongService(CapturedOutput output) {
+  void shouldFilterMessageForWrongService() {
 
     //Set wrong blob name
     myEvent.setSubject("/blobServices/default/containers/" + container
@@ -164,7 +161,6 @@ class RtdMsDecrypterApplicationTest {
       verify(blobRestConnectorImpl, times(0)).put(any());
       verify(blobApplicationAware, times(0)).localCleanup();
       verify(handler, times(1)).blobStorageConsumer(any(), any(), any(), any());
-      assertThat(output.getOut(), containsString("Wrong name format:"));
     });
   }
 

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandlerTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/event/EventHandlerTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import it.gov.pagopa.rtd.ms.rtdmsdecrypter.model.BlobApplicationAware;
-import it.gov.pagopa.rtd.ms.rtdmsdecrypter.model.BlobApplicationAware.Status;
 import it.gov.pagopa.rtd.ms.rtdmsdecrypter.model.EventGridEvent;
 import it.gov.pagopa.rtd.ms.rtdmsdecrypter.service.BlobRestConnectorImpl;
 import it.gov.pagopa.rtd.ms.rtdmsdecrypter.service.BlobSplitterImpl;
@@ -102,6 +101,7 @@ class EventHandlerTest {
     blobDownloaded.setStatus(BlobApplicationAware.Status.DOWNLOADED);
     blobDecrypted.setStatus(BlobApplicationAware.Status.DECRYPTED);
     blobVerified.setStatus(BlobApplicationAware.Status.VERIFIED);
+    blobVerified.setOrigianalFileChunksNumber(3);
     blobSplit.setStatus(BlobApplicationAware.Status.SPLIT);
     blobUploaded.setStatus(BlobApplicationAware.Status.UPLOADED);
     doReturn(blobDownloaded).when(blobRestConnectorImpl).get(any(BlobApplicationAware.class));

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobSplitterTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobSplitterTest.java
@@ -173,7 +173,7 @@ class BlobSplitterTest {
     ArrayList<BlobApplicationAware> originalMissingBlob = (ArrayList<BlobApplicationAware>) chunks.collect(
         Collectors.toList());
     assertEquals(1, originalMissingBlob.size());
-    assertEquals(Status.DOWNLOADED, originalMissingBlob.get(0).getStatus());
+    assertEquals(Status.DELETED, originalMissingBlob.get(0).getStatus());
   }
 
 }

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobVerifierTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobVerifierTest.java
@@ -76,7 +76,7 @@ class BlobVerifierTest {
         "/blobServices/default/containers/" + containerRTD + "/blobs/" + blobNameRTD
             + ".decrypted");
     fakeBlobRTD.setTargetDir(tmpDirectory);
-    fakeBlobRTD.setStatus(Status.DECRYPTED);
+    fakeBlobRTD.setStatus(Status.SPLIT);
     fakeBlobRTD.setApp(Application.RTD);
 
     //Create the decrypted file for TAE
@@ -92,7 +92,7 @@ class BlobVerifierTest {
         "/blobServices/default/containers/" + containerTAE + "/blobs/" + blobNameTAE
             + ".decrypted");
     fakeBlobTAE.setTargetDir(tmpDirectory);
-    fakeBlobTAE.setStatus(Status.DECRYPTED);
+    fakeBlobTAE.setStatus(Status.SPLIT);
     fakeBlobTAE.setApp(Application.ADE);
 
     //Create the decrypted empty file for TAE
@@ -108,7 +108,7 @@ class BlobVerifierTest {
         "/blobServices/default/containers/" + containerTAE + "/blobs/" + blobNameTAEEmpty
             + ".decrypted");
     fakeBlobTAEEmpty.setTargetDir(tmpDirectory);
-    fakeBlobTAEEmpty.setStatus(Status.DECRYPTED);
+    fakeBlobTAEEmpty.setStatus(Status.SPLIT);
     fakeBlobTAEEmpty.setApp(Application.ADE);
 
     //Create the decrypted empty file for RTD
@@ -124,7 +124,7 @@ class BlobVerifierTest {
         "/blobServices/default/containers/" + containerRTD + "/blobs/" + blobNameRTDEmpty
             + ".decrypted");
     fakeBlobRTDEmpty.setTargetDir(tmpDirectory);
-    fakeBlobRTDEmpty.setStatus(Status.DECRYPTED);
+    fakeBlobRTDEmpty.setStatus(Status.SPLIT);
     fakeBlobRTDEmpty.setApp(Application.RTD);
   }
 
@@ -180,7 +180,7 @@ class BlobVerifierTest {
         malformedAggregateRecord.getBytes(), StandardOpenOption.APPEND);
 
     blobVerifierImpl.verify(fakeBlobTAEEmpty);
-    assertEquals(Status.DELETED, fakeBlobTAEEmpty.getStatus());
+    assertEquals(Status.SPLIT, fakeBlobTAEEmpty.getStatus());
   }
 
 
@@ -254,7 +254,7 @@ class BlobVerifierTest {
         malformedAggregateRecord.getBytes(), StandardOpenOption.APPEND);
 
     blobVerifierImpl.verify(fakeBlobRTDEmpty);
-    assertEquals(Status.DELETED, fakeBlobRTDEmpty.getStatus());
+    assertEquals(Status.SPLIT, fakeBlobRTDEmpty.getStatus());
   }
 
   @ParameterizedTest
@@ -267,7 +267,7 @@ class BlobVerifierTest {
     blobVerifierImpl.setSkipChecksum(false);
 
     blobVerifierImpl.verify(fakeBlobRTDEmpty);
-    assertEquals(Status.DELETED, fakeBlobRTDEmpty.getStatus());
+    assertEquals(Status.SPLIT, fakeBlobRTDEmpty.getStatus());
   }
 
   @Test


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR proposes to validate deserialized records using stream instead of loading all the beans in memory.

#### List of Changes
- add stream validation
- add check to handle only events with all chunks verified
- grant 4GB of max heap size to the JVM
<!--- Describe your changes in detail -->

#### Motivation and Context
With this change we can process chunks up to 4 million rows with an handling time of around 1 minute per million rows.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Unit Test Suite
- [x] Integration Test Suite
- [ ] Api Tests
- [x] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.