### PR TITLE
fix: [TAE-301] Refactor aggregates validation method to rationalize logs

### DIFF
--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/WalletExportHeader.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/model/WalletExportHeader.java
@@ -20,15 +20,15 @@ public class WalletExportHeader {
 
   @JsonProperty("tenant_id")
   @NotNull
-  private String tenant_id;
+  private String tenantId;
 
   @JsonProperty("merchant_id")
   @NotNull
-  private String merchant_id;
+  private String merchantId;
 
   @JsonProperty("terminal_id")
   @NotNull
-  private String terminal_id;
+  private String terminalId;
 
   @JsonProperty("processing_start_time")
   @NotNull

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/AdeAggregatesVerifier.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/AdeAggregatesVerifier.java
@@ -10,6 +10,7 @@ import jakarta.validation.ValidatorFactory;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Iterator;
 import java.util.Set;
 
 /**
@@ -18,57 +19,85 @@ import java.util.Set;
  */
 public class AdeAggregatesVerifier implements BeanVerifier<AdeTransactionsAggregate> {
 
+  static String malformedFieldMessage = "Malformed field extracted:";
   private static final ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 
   private static final Validator validator = factory.getValidator();
 
   /**
-   * Implementation of {@link BeanVerifier#verifyBean(Object)}, used to verify the
-   * validity of the
+   * Implementation of {@link BeanVerifier#verifyBean(Object)}, used to verify the validity of the
    * {@link AdeTransactionsAggregate} records extracted from the decrypted file.
    *
-   * @param adeTransactionsAggregate The {@link AdeTransactionsAggregate} to be
-   *                                 verified
+   * @param adeTransactionsAggregate The {@link AdeTransactionsAggregate} to be verified
    * @return Boolean representing the validity of the record
    * @throws CsvConstraintViolationException in case of malformed fields
    */
   @Override
   public boolean verifyBean(AdeTransactionsAggregate adeTransactionsAggregate)
       throws CsvConstraintViolationException {
+    StringBuilder malformedFields = new StringBuilder();
+
     Set<ConstraintViolation<AdeTransactionsAggregate>> violations = validator.validate(
         adeTransactionsAggregate);
 
     if (!violations.isEmpty()) {
-      StringBuilder malformedFields = new StringBuilder();
-      for (ConstraintViolation<AdeTransactionsAggregate> violation : violations) {
-        if (!violation.getPropertyPath().toString().equals("acquirerCode")) {
-          malformedFields.append(String.format("[ Acquirer code: %s ] ",
-              adeTransactionsAggregate.getAcquirerCode()));
+      Iterator<ConstraintViolation<AdeTransactionsAggregate>> violationIterator = violations.iterator();
+
+      boolean acquirerCodeAppended = false;
+      boolean terminalIdAppended = false;
+      boolean fiscalCodeAppended = false;
+
+      while (violationIterator.hasNext()) {
+        ConstraintViolation<AdeTransactionsAggregate> violation = violationIterator.next();
+        String propertyPath = violation.getPropertyPath().toString();
+
+        if (adeTransactionsAggregate.getAcquirerCode() != null
+            && !adeTransactionsAggregate.getAcquirerCode().isEmpty() && !acquirerCodeAppended
+            && !propertyPath.equals("acquirerCode")) {
+          malformedFields.append(
+              String.format("[ Acquirer code: %s ] ", adeTransactionsAggregate.getAcquirerCode()));
+          acquirerCodeAppended = true;
         }
-        if (!violation.getPropertyPath().toString().equals("terminalId")) {
-          malformedFields.append(String.format("[ Terminal id: %s ] ",
-              adeTransactionsAggregate.getTerminalId()));
+        if (adeTransactionsAggregate.getTerminalId() != null
+            && adeTransactionsAggregate.getTerminalId().isEmpty() && !terminalIdAppended
+            && !propertyPath.equals("terminalId")) {
+          malformedFields.append(
+              String.format("[ Terminal id: %s ] ", adeTransactionsAggregate.getTerminalId()));
+          terminalIdAppended = true;
         }
-        if (!violation.getPropertyPath().toString().equals("fiscalCode")) {
-          malformedFields.append(String.format("[ Fiscal code: %s ] ",
-              adeTransactionsAggregate.getFiscalCode()));
+        if (adeTransactionsAggregate.getFiscalCode() != null
+            && adeTransactionsAggregate.getFiscalCode().isEmpty() && !fiscalCodeAppended
+            && !propertyPath.equals("fiscalCode")) {
+          malformedFields.append(
+              String.format("[ Fiscal code: %s ] ", adeTransactionsAggregate.getFiscalCode()));
+          fiscalCodeAppended = true;
         }
-        malformedFields.append("Malformed fields extracted : (")
+
+        malformedFields.append(malformedFieldMessage).append(" (")
             .append(violation.getPropertyPath().toString()).append(": ");
-        malformedFields.append(violation.getMessage()).append(") ");
+        malformedFields.append(violation.getMessage()).append("), ");
       }
+    }
 
+    if (adeTransactionsAggregate.getTransmissionDate() == null || !validateDate(
+        adeTransactionsAggregate.getTransmissionDate())) {
+      malformedFields.append(malformedFieldMessage).append(" (")
+          .append("transmission date").append(": ");
+      malformedFields.append("Invalid transmission date ")
+          .append(adeTransactionsAggregate.getTransmissionDate())
+          .append("), ");
+    }
+    if (adeTransactionsAggregate.getAccountingDate() == null || !validateDate(
+        adeTransactionsAggregate.getAccountingDate())) {
+      malformedFields.append(malformedFieldMessage).append(" (")
+          .append("accounting date").append(": ");
+      malformedFields.append("Invalid accounting date ")
+          .append(adeTransactionsAggregate.getAccountingDate())
+          .append("), ");
+    }
+
+    if (!malformedFields.isEmpty()) {
       throw new CsvConstraintViolationException(malformedFields.toString());
-    }
-
-    if (!validateDate(adeTransactionsAggregate.getTransmissionDate())) {
-      throw new CsvConstraintViolationException(
-          "Invalid transmission date " + adeTransactionsAggregate.getTransmissionDate());
-
-    }
-    if (!validateDate(adeTransactionsAggregate.getAccountingDate())) {
-      throw new CsvConstraintViolationException(
-          "Invalid accounting date " + adeTransactionsAggregate.getAccountingDate());
     }
 
     return true;

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/AdeAggregatesVerifier.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/AdeAggregatesVerifier.java
@@ -44,48 +44,16 @@ public class AdeAggregatesVerifier implements BeanVerifier<AdeTransactionsAggreg
     if (!violations.isEmpty()) {
       Iterator<ConstraintViolation<AdeTransactionsAggregate>> violationIterator = violations.iterator();
 
-      boolean acquirerCodeAppended = false;
-      boolean terminalIdAppended = false;
-      boolean fiscalCodeAppended = false;
-
       while (violationIterator.hasNext()) {
         ConstraintViolation<AdeTransactionsAggregate> violation = violationIterator.next();
-        String propertyPath = violation.getPropertyPath().toString();
-
-        if (adeTransactionsAggregate.getAcquirerCode() != null
-            && !adeTransactionsAggregate.getAcquirerCode().isEmpty() && !acquirerCodeAppended
-            && !propertyPath.equals("acquirerCode")) {
-          recordTroubleshootingInfo.append(
-              String.format("[Acquirer code: %s] ", adeTransactionsAggregate.getAcquirerCode()));
-          acquirerCodeAppended = true;
-        }
-        if (adeTransactionsAggregate.getTerminalId() != null
-            && adeTransactionsAggregate.getTerminalId().isEmpty() && !terminalIdAppended
-            && !propertyPath.equals("terminalId")) {
-          recordTroubleshootingInfo.append(
-              String.format("[Terminal id: %s] ", adeTransactionsAggregate.getTerminalId()));
-          terminalIdAppended = true;
-        }
-        if (adeTransactionsAggregate.getFiscalCode() != null
-            && adeTransactionsAggregate.getFiscalCode().isEmpty() && !fiscalCodeAppended
-            && !propertyPath.equals("fiscalCode")) {
-          recordTroubleshootingInfo.append(
-              String.format("[Fiscal code: %s] ", adeTransactionsAggregate.getFiscalCode()));
-          fiscalCodeAppended = true;
-        }
 
         malformedFields.append(malformedFieldMessage).append(" (")
             .append(violation.getPropertyPath().toString()).append(": ");
         malformedFields.append(violation.getMessage()).append("), ");
       }
-    } else {
-      recordTroubleshootingInfo.append(
-          String.format("[Acquirer code: %s] ", adeTransactionsAggregate.getAcquirerCode()));
-      recordTroubleshootingInfo.append(
-          String.format("[Terminal id: %s] ", adeTransactionsAggregate.getTerminalId()));
-      recordTroubleshootingInfo.append(
-          String.format("[Fiscal code: %s] ", adeTransactionsAggregate.getFiscalCode()));
     }
+
+    parseTroubleshootingInfo(adeTransactionsAggregate, recordTroubleshootingInfo);
 
     // Timestamps validity must be verified outside violations iterator
 
@@ -121,6 +89,25 @@ public class AdeAggregatesVerifier implements BeanVerifier<AdeTransactionsAggreg
       return true;
     } catch (DateTimeParseException e) {
       return false;
+    }
+  }
+
+  private void parseTroubleshootingInfo(AdeTransactionsAggregate adeTransactionsAggregate,
+      StringBuilder recordTroubleshootingInfo) {
+    if (adeTransactionsAggregate.getAcquirerCode() != null
+        && !adeTransactionsAggregate.getAcquirerCode().isEmpty()) {
+      recordTroubleshootingInfo.append(
+          String.format("[Acquirer code: %s] ", adeTransactionsAggregate.getAcquirerCode()));
+    }
+    if (adeTransactionsAggregate.getTerminalId() != null
+        && !adeTransactionsAggregate.getTerminalId().isEmpty()) {
+      recordTroubleshootingInfo.append(
+          String.format("[Terminal id: %s] ", adeTransactionsAggregate.getTerminalId()));
+    }
+    if (adeTransactionsAggregate.getFiscalCode() != null
+        && !adeTransactionsAggregate.getFiscalCode().isEmpty()) {
+      recordTroubleshootingInfo.append(
+          String.format("[Fiscal code: %s] ", adeTransactionsAggregate.getFiscalCode()));
     }
   }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobRestConnectorImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsdecrypter/service/BlobRestConnectorImpl.java
@@ -157,7 +157,7 @@ public class BlobRestConnectorImpl implements BlobRestConnector {
     if(blob.getApp()==Application.WALLET){
       return blob;
     }
-    log.info("Start SET metadata for  {} to {}. CheckSum {}", blob.getBlob(), blob.getContainer(),blob.getReportMetaData().getCheckSum());
+    log.info("Start SET metadata for {} to {}. CheckSum {}", blob.getBlob(), blob.getContainer(),blob.getReportMetaData().getCheckSum());
 
     String uri = baseUrl + "/" + blobBasePath + "/" + blob.getContainer() + "/" + blob.getBlob()
         + BLOB_METADATA_QUERY;


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to fix a logging problem when the deserialized record has validation errors.
#### List of Changes
- refactor violations iteration logic.
<!--- Describe your changes in detail -->

#### Motivation and Context
With this change we minimize and refine printed troubleshooting information.
The following log:
```
Validation error at line 1 : [ Acquirer code: 00000 ] [ Terminal id: 9999999999999999999 ] [ Fiscal code: 00000000003 ] Malformed fields extracted : (posType: size must be between 2 and 2) [ Acquirer code: 00000 ] [ Terminal id: 4759769053262163701 ] [ Fiscal code: 00000000003 ] Malformed fields extracted : (posType: must match "00|01|99")
```
became:
```
Validation error at line 1 : [Acquirer code: 00000] [Terminal id: 9999999999999999999] [Fiscal code: 00000000003] Malformed field extracted: (posType: must match "00|01|99"), Malformed field extracted: (posType: size must be between 2 and 2)
```
`Acquirer code`, `Terminal id`, `Fiscal code` are no longer printed as additional info if they are missing.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [x] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.