### PR TITLE
fix: [TAE-366] use appinsights connection string due to support ending

### DIFF
--- a/.devops/cstar-rtd-code-review-pipelines.yml
+++ b/.devops/cstar-rtd-code-review-pipelines.yml
@@ -11,7 +11,6 @@ pr:
       - uat
 
 pool:
-  #vmImage: 'ubuntu-latest'
   vmImage: ubuntu-24.04
 
 #variables:

--- a/helm/rtd/values.yaml
+++ b/helm/rtd/values.yaml
@@ -45,7 +45,7 @@ microservice-chart:
     runAsGroup: 65534
 
   envSecret:
-    APPLICATIONINSIGHTS_CONNECTION_STRING: appinsights-instrumentation-key
+    APPLICATIONINSIGHTS_CONNECTION_STRING: appinsights-connection-string
     KAFKA_SASL_JAAS_CONFIG_CONSUMER_BLOB_STORAGE_EVENTS: evh-rtd-platform-events-rtd-platform-events-sub-rtd
     INTERNAL_SERVICES_API_KEY: rtd-internal-api-product-subscription-key
     CSV_TRANSACTION_PRIVATE_KEY: cstarblobstorage-private-key

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     </parent>
     <groupId>it.gov.pagopa.rtd.ms</groupId>
     <artifactId>rtd-ms-decrypter</artifactId>
-    <version>1.2.8</version>
+    <version>1.2.9</version>
     <name>rtd-ms-decrypter</name>
     <description>Microservice capable of decrypting PGP files</description>
     <properties>


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Since instrumentation key support ended on March 31, the change provide the use of the application connection string for Application Insights instead of providing the instrumentation key directly.

#### Motivation and Context
https://learn.microsoft.com/it-it/azure/azure-monitor/app/connection-strings

As of March 31, instrumentation key support has ended.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.